### PR TITLE
fix: add return type to CRUD methods

### DIFF
--- a/example/src/screens/NetworkClientScreen.tsx
+++ b/example/src/screens/NetworkClientScreen.tsx
@@ -127,7 +127,7 @@ const RequestHeader = ({index, header, updateHeader}) => {
 }
 
 
-export default function GenericClientScreen({navigation, route}) {
+export default function NetworkClientScreen({navigation, route}) {
     const {name, client} = route.params;
 
     const [method, setMethod] = useState('GET');
@@ -150,16 +150,19 @@ export default function GenericClientScreen({navigation, route}) {
     const sanitizeHeaders = (headersArray) => {
         const headers = {};
         headersArray.forEach(({key, value}) => {
-           if (key && value) {
-            headers[key] = value;
-           } 
+            if (key && value) {
+                headers[key] = value;
+            } 
         });
 
         return headers;
     }
 
     const makeRequest = async () => {
-        const options = sanitizeHeaders(requestHeaders);
+        const options = {
+            headers: sanitizeHeaders(requestHeaders),
+            body: JSON.parse(body),
+        };
         let requestMethod;
         switch (method.toLowerCase().trim()) {
             case 'get':

--- a/src/ApiClient/index.tsx
+++ b/src/ApiClient/index.tsx
@@ -6,6 +6,7 @@ import isURL from 'validator/es/lib/isURL';
 
 import type {
   RequestOptions,
+  Response,
   GenericClientInterface,
   ApiClientInterface,
   ApiClientConfiguration,
@@ -30,14 +31,14 @@ class ApiClient implements ApiClientInterface {
       this.baseUrl = baseUrl;
   }
 
-  getHeaders = () => NetworkClient.getApiClientHeadersFor(this.baseUrl);
-  addHeaders = (headers: object) => NetworkClient.addApiClientHeadersFor(this.baseUrl, headers);
+  getHeaders = (): Promise<object> => NetworkClient.getApiClientHeadersFor(this.baseUrl);
+  addHeaders = (headers: object): void => NetworkClient.addApiClientHeadersFor(this.baseUrl, headers);
 
-  get = (endpoint: string, options?: RequestOptions) => NetworkClient.get(this.baseUrl, endpoint, options);
-  put = (endpoint: string, options?: RequestOptions) => NetworkClient.put(this.baseUrl, endpoint, options);
-  post = (endpoint: string, options?: RequestOptions) => NetworkClient.post(this.baseUrl, endpoint, options);
-  patch = (endpoint: string, options?: RequestOptions) => NetworkClient.patch(this.baseUrl, endpoint, options);
-  delete = (endpoint: string, options?: RequestOptions) => NetworkClient.delete(this.baseUrl, endpoint, options);
+  get = (endpoint: string, options?: RequestOptions): Promise<Response> => NetworkClient.get(this.baseUrl, endpoint, options);
+  put = (endpoint: string, options?: RequestOptions): Promise<Response> => NetworkClient.put(this.baseUrl, endpoint, options);
+  post = (endpoint: string, options?: RequestOptions): Promise<Response> => NetworkClient.post(this.baseUrl, endpoint, options);
+  patch = (endpoint: string, options?: RequestOptions): Promise<Response> => NetworkClient.patch(this.baseUrl, endpoint, options);
+  delete = (endpoint: string, options?: RequestOptions): Promise<Response> => NetworkClient.delete(this.baseUrl, endpoint, options);
 }
 
 const CLIENTS: {[key: string]: ApiClient} = {};

--- a/src/ApiClient/types.tsx
+++ b/src/ApiClient/types.tsx
@@ -8,6 +8,11 @@ export type RequestOptions = {
     body?: any;
 }
 
+export type Response = {
+    headers?: object;
+    data?: any,
+}
+
 export interface GenericClientInterface {
     get(endpoint: string, options?: RequestOptions): any;
 }


### PR DESCRIPTION
#### Summary
* Add `Promise<Response>` return type for CRUD methods. The `Response` type is a WIP and includes optional headers and data for now so that we know what the example app expects as a response
* Include body in POST request

