### PR TITLE
Revert back to creating sessions using baseUrl instead of host

### DIFF
--- a/example/src/screens/APIClientFastImageScreen.tsx
+++ b/example/src/screens/APIClientFastImageScreen.tsx
@@ -9,7 +9,9 @@ import Icon from "react-native-vector-icons/MaterialIcons";
 
 const APIClientFastImageScreen = ({ route }: APIClientFastImageScreenProps) => {
     const { client } = route.params;
-    const [imageUrl, setImageUrl] = useState(client.baseUrl);
+    const [imageUrl, setImageUrl] = useState(
+        `${client.baseUrl}/api/v4/files/xjiid3qaa38kjxxwr9mxbfxyco`
+    );
     const [loading, setLoading] = useState(false);
     const [errored, setErrored] = useState(false);
 
@@ -22,7 +24,7 @@ const APIClientFastImageScreen = ({ route }: APIClientFastImageScreenProps) => {
         <SafeAreaView style={{ flex: 1 }}>
             <Input
                 label="Image URL"
-                placeholder="/api/v4/system/ping"
+                placeholder={`${client.baseUrl}/image.png`}
                 value={imageUrl}
                 onChangeText={setImageUrl}
                 autoCapitalize="none"
@@ -43,7 +45,7 @@ const APIClientFastImageScreen = ({ route }: APIClientFastImageScreenProps) => {
                     onLoad={onLoad}
                     onError={onError}
                     resizeMode={FastImage.resizeMode.contain}
-                    style={{ height: 500, width: 500 }}
+                    style={{ height: 400, width: 400 }}
                 />
             </View>
         </SafeAreaView>

--- a/example/src/screens/APIClientRequestScreen.tsx
+++ b/example/src/screens/APIClientRequestScreen.tsx
@@ -15,9 +15,13 @@ import { parseHeaders, METHODS } from "../utils";
 
 const APIClientRequestScreen = ({ route }: APIClientRequestScreenProps) => {
     const { client, method } = route.params;
-    const [endpoint, setEndpoint] = useState("/api/v4/system/ping");
+    const [endpoint, setEndpoint] = useState(
+        method === METHODS.POST ? "/api/v4/users/login" : "/api/v4/users/me"
+    );
     const [timeoutInterval, setTimeoutInterval] = useState(30);
-    const [body, setBody] = useState('{"login_id":"","password":""}');
+    const [body, setBody] = useState(
+        '{"login_id":"username","password":"password"}'
+    );
     const [requestHeaders, setRequestHeaders] = useState<Header[]>([]);
     const [response, setResponse] = useState<ClientResponse>();
     const [responseVisible, setResponseVisible] = useState(false);
@@ -106,7 +110,7 @@ const APIClientRequestScreen = ({ route }: APIClientRequestScreenProps) => {
         <SafeAreaView>
             <ScrollView>
                 <Input
-                    label={`GET\n\n${client.baseUrl}`}
+                    label={`${method}\n\n${client.baseUrl}`}
                     placeholder="/api/v4/system/ping"
                     value={endpoint}
                     onChangeText={setEndpoint}

--- a/example/src/utils/index.tsx
+++ b/example/src/utils/index.tsx
@@ -34,7 +34,7 @@ export const createMattermostAPIClient = async (): Promise<APIClientItem | null>
         timeoutIntervalForRequest: 30,
         timeoutIntervalForResource: 30,
         httpMaximumConnectionsPerHost: 10,
-        cancelRequestsOnUnauthorized: false,
+        cancelRequestsOnUnauthorized: true,
     };
     const retryPolicyConfiguration = {
         type: undefined,
@@ -43,7 +43,7 @@ export const createMattermostAPIClient = async (): Promise<APIClientItem | null>
         exponentialBackoffScale: 0.5,
     };
     const requestAdapterConfiguration = {
-        bearerAuthTokenResponseHeader: "",
+        bearerAuthTokenResponseHeader: "token",
     };
 
     const options: APIClientConfiguration = {

--- a/ios/APIClient.swift
+++ b/ios/APIClient.swift
@@ -16,7 +16,7 @@ class APIClient: NetworkClient {
     
     @objc(createClientFor:withOptions:withResolver:withRejecter:)
     func createClientFor(baseUrlString: String, options: Dictionary<String, Any>?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        guard let host = URL(string: baseUrlString)?.host else {
+        guard let baseUrl = URL(string: baseUrlString) else {
             rejectMalformed(url: baseUrlString, withRejecter: reject)
             return
         }
@@ -30,7 +30,7 @@ class APIClient: NetworkClient {
             let bearerAuthTokenResponseHeader = options["requestAdapterConfiguration"]["bearerAuthTokenResponseHeader"].string
 
             resolve(
-                SessionManager.default.createSession(for: host,
+                SessionManager.default.createSession(for: baseUrl,
                                                      withConfiguration: configuration,
                                                      withInterceptor: interceptor,
                                                      withRedirectHandler: redirectHandler,
@@ -41,49 +41,49 @@ class APIClient: NetworkClient {
             return
         }
         
-        resolve(SessionManager.default.createSession(for: host))
+        resolve(SessionManager.default.createSession(for: baseUrl))
     }
 
     @objc(invalidateClientFor:withResolver:withRejecter:)
     func invalidateClientFor(baseUrlString: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {        
-        guard let host = URL(string: baseUrlString)?.host else {
+        guard let baseUrl = URL(string: baseUrlString) else {
             rejectMalformed(url: baseUrlString, withRejecter: reject)
             return
         }
 
-        KeychainWrapper.standard.removeObject(forKey: host)
+        KeychainWrapper.standard.removeObject(forKey: baseUrl.absoluteString)
 
-        resolve(SessionManager.default.invalidateSession(for: host))
+        resolve(SessionManager.default.invalidateSession(for: baseUrl))
     }
 
     @objc(addClientHeadersFor:withHeaders:withResolver:withRejecter:)
     func addClientHeadersFor(baseUrlString: String, headers: Dictionary<String, String>, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        guard let host = URL(string: baseUrlString)?.host else {
+        guard let baseUrl = URL(string: baseUrlString) else {
             rejectMalformed(url: baseUrlString, withRejecter: reject)
             return
         }
 
-        if SessionManager.default.getSession(for: host) == nil {
-            rejectInvalidSession(for: host, withRejecter: reject)
+        if SessionManager.default.getSession(for: baseUrl) == nil {
+            rejectInvalidSession(for: baseUrl, withRejecter: reject)
             return
         }
 
-        resolve(SessionManager.default.addSessionHeaders(for: host, additionalHeaders: headers))
+        resolve(SessionManager.default.addSessionHeaders(for: baseUrl, additionalHeaders: headers))
     }
 
     @objc(getClientHeadersFor:withResolver:withRejecter:)
     func getClientHeadersFor(baseUrlString: String, resolve: @escaping RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        guard let host = URL(string: baseUrlString)?.host else {
+        guard let baseUrl = URL(string: baseUrlString) else {
             rejectMalformed(url: baseUrlString, withRejecter: reject)
             return
         }
 
-        if SessionManager.default.getSession(for: host) == nil {
-            rejectInvalidSession(for: host, withRejecter: reject)
+        if SessionManager.default.getSession(for: baseUrl) == nil {
+            rejectInvalidSession(for: baseUrl, withRejecter: reject)
             return
         }
 
-        let headers = JSON(SessionManager.default.getSessionHeaders(for: host)).dictionaryObject
+        let headers = JSON(SessionManager.default.getSessionHeaders(for: baseUrl)).dictionaryObject
         resolve(headers)
     }
     
@@ -113,13 +113,13 @@ class APIClient: NetworkClient {
     }
     
     func handleRequest(for baseUrlString: String, withEndpoint endpoint: String, withMethod method: HTTPMethod, withOptions options: JSON, withResolver resolve: @escaping RCTPromiseResolveBlock, withRejecter reject: RCTPromiseRejectBlock) -> Void {
-        guard let baseUrl = URL(string: baseUrlString), let host = baseUrl.host else {
+        guard let baseUrl = URL(string: baseUrlString) else {
             rejectMalformed(url: baseUrlString, withRejecter: reject)
             return
         }
     
-        guard let session = SessionManager.default.getSession(for: host) else {
-            rejectInvalidSession(for: host, withRejecter: reject)
+        guard let session = SessionManager.default.getSession(for: baseUrl) else {
+            rejectInvalidSession(for: baseUrl, withRejecter: reject)
             return
         }
 
@@ -132,7 +132,7 @@ class APIClient: NetworkClient {
             session.cancelAllRequests()
         } else if let tokenHeader = session.bearerAuthTokenResponseHeader {
             if let token = data.response?.allHeaderFields[tokenHeader] as? String {
-                KeychainWrapper.standard.set(token, forKey: url.host!)
+                KeychainWrapper.standard.set(token, forKey: session.baseUrl.absoluteString)
             }
         }
     }
@@ -170,8 +170,8 @@ class APIClient: NetworkClient {
         return config
     }
 
-    func rejectInvalidSession(for host: String, withRejecter reject: RCTPromiseRejectBlock) -> Void {
-        let message = "Session for \(host) has been invalidated"
+    func rejectInvalidSession(for baseUrl: URL, withRejecter reject: RCTPromiseRejectBlock) -> Void {
+        let message = "Session for \(baseUrl.absoluteString) has been invalidated"
         let error = NSError(domain: "com.mattermost.react-native-network-client", code: NSCoderValueNotFoundError, userInfo: [NSLocalizedDescriptionKey: message])
         reject("\(error.code)", message, error)
     }

--- a/ios/BearerAuthenticationAdapter.swift
+++ b/ios/BearerAuthenticationAdapter.swift
@@ -12,9 +12,9 @@ import Alamofire
 import SwiftKeychainWrapper
 
 @objc public class BearerAuthenticationAdapter: NSObject, RequestAdapter {
-    @objc public static func addAuthorizationBearerToken(to urlRequest: URLRequest) -> URLRequest {
+    @objc public static func addAuthorizationBearerToken(to urlRequest: URLRequest, withSessionBaseUrlString sessionBaseUrlString: String) -> URLRequest {
         var urlRequest = urlRequest
-        if let bearerToken = KeychainWrapper.standard.string(forKey: urlRequest.url!.host!) {
+        if let bearerToken = KeychainWrapper.standard.string(forKey: sessionBaseUrlString) {
             urlRequest.headers.add(.authorization(bearerToken: bearerToken))
         }
         
@@ -22,7 +22,7 @@ import SwiftKeychainWrapper
     }
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest)
+        let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest, withSessionBaseUrlString: session.baseUrl.absoluteString)
 
         completion(.success(urlRequest))
     }

--- a/ios/NetworkClient.swift
+++ b/ios/NetworkClient.swift
@@ -131,7 +131,7 @@ class NetworkClient: NSObject, ResponseHandler {
     }
 
     func rejectMalformed(url: String, withRejecter reject: RCTPromiseRejectBlock) -> Void {
-        let message = "Malformed URL \(url)"
+        let message = "Malformed URL: \(url)"
         let error = NSError(domain: "com.mattermost.react-native-network-client", code: NSURLErrorBadURL, userInfo: [NSLocalizedDescriptionKey: message])
         reject("\(error.code)", message, error)
     }

--- a/ios/Session+NetworkClient.swift
+++ b/ios/Session+NetworkClient.swift
@@ -15,9 +15,15 @@ extension Session: Equatable {
     }
 }
 
+fileprivate var baseUrl_FILEPRIVATE : [ObjectIdentifier:URL] = [:]
 fileprivate var cancelRequestsOnUnauthorized_FILEPRIVATE : [ObjectIdentifier:Bool] = [:]
 fileprivate var bearerAuthTokenResponseHeader_FILEPRIVATE : [ObjectIdentifier:String] = [:]
 extension Session {
+    var baseUrl: URL {
+        get { return baseUrl_FILEPRIVATE[ObjectIdentifier(self)]!}
+        set { baseUrl_FILEPRIVATE[ObjectIdentifier(self)] = newValue}
+    }
+
     var cancelRequestsOnUnauthorized: Bool {
         get { return cancelRequestsOnUnauthorized_FILEPRIVATE[ObjectIdentifier(self)] ?? false }
         set { cancelRequestsOnUnauthorized_FILEPRIVATE[ObjectIdentifier(self)] = newValue }


### PR DESCRIPTION
#### Summary
This is based on https://github.com/mattermost/react-native-network-client/pull/23. Changes for this PR are in commit https://github.com/mattermost/react-native-network-client/commit/518f4a395d9eda0dce18b7be4ffc5ba63b21258c.

When swizzling SDWebImageDownloader for RN Fast Image, it was easy to find our own session for the image request if we created sessions by using the `host` value rather than the supplied `baseUrl`, since we can easily get the `host` from `request.host` in SDWebImageDownloader. This, however, introduces some other problems (see this [mattermost conversation](https://community.mattermost.com/core/pl/1r89uyif8tf6m8rb5ogrqmqtyy)). This PR reverts back to using the baseUrl for session creation and updates the swizzled SDWebImageDowloader to use a new SessionManager function that attempts to find an existing session by stripping path components from the request URL.

