### PR TITLE
[MM-31035] Android TLS + Swizzle

### DIFF
--- a/@types/APIClients.ts
+++ b/@types/APIClients.ts
@@ -58,6 +58,13 @@ interface APIClientInterface {
     invalidate(): Promise<void>;
 }
 
+type CertificateConfiguration = {
+    rootCertificate?: string;
+    pinnedCertificate?: string;
+    pinnedHost?: string;
+    clientCertificate?: string;
+};
+
 type SessionConfiguration = {
     followRedirects?: boolean;
     allowsCellularAccess?: boolean;
@@ -86,6 +93,7 @@ type APIClientConfiguration = {
     requestAdapterConfiguration?: RequestAdapterConfiguration;
     serverTrustManagerConfig?: Record<string, string>;
     cachedResponseHandlerConfig?: Record<string, string>;
+    certificateConfig?: CertificateConfiguration;
 };
 
 type UploadProgressEvent = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,4 +128,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.squareup.okhttp3:okhttp:4.9.0"
+  implementation "com.squareup.okhttp3:okhttp-tls:4.9.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,6 +127,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.21"
   implementation "com.squareup.okhttp3:okhttp:4.9.0"
   implementation "com.squareup.okhttp3:okhttp-tls:4.9.0"
 }

--- a/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
@@ -9,8 +9,8 @@ import java.util.*
 
 class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
-    var sessionsClient = mutableMapOf<String, OkHttpClient.Builder>()
-    var sessionsRequest = mutableMapOf<String, Request.Builder>()
+    private val sessionsClient = SessionsObject.client
+    private val sessionsRequest = SessionsObject.request
 
     override fun getName(): String {
         return "APIClient"

--- a/android/src/main/java/com/mattermost/networkclient/Helper.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Helper.kt
@@ -6,7 +6,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 
 import okhttp3.*
-import okhttp3.tls.Certificates;
+//import okhttp3.tls.Certificates;
 import okhttp3.tls.HandshakeCertificates;
 import java.util.concurrent.TimeUnit
 
@@ -140,9 +140,11 @@ fun OkHttpClient.Builder.parseOptions(options: ReadableMap): OkHttpClient.Builde
 
 
             // Add the client certificate if provided
-            if(certsConfig.hasKey("clientCertificatePem")) {
+            if(certsConfig.hasKey("clientCertificate")) {
                 val clientCertificate = HeldCertificate.decode(certsConfig.getString("clientPublicCertificate")!!)
                 certificatesBuilder = certificatesBuilder.heldCertificate(clientCertificate)
+            } else {
+
             }
 
             // Build and add to the client

--- a/android/src/main/java/com/mattermost/networkclient/SessionsObject.kt
+++ b/android/src/main/java/com/mattermost/networkclient/SessionsObject.kt
@@ -1,0 +1,9 @@
+package com.mattermost.networkclient
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+object SessionsObject {
+    var client = mutableMapOf<String, OkHttpClient.Builder>()
+    var request = mutableMapOf<String, Request.Builder>()
+}

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/GlobalInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/GlobalInterceptor.kt
@@ -1,0 +1,30 @@
+package com.mattermost.networkclient.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import com.mattermost.networkclient.SessionsObject
+
+class GlobalInterceptor() : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+
+        // Get our singletons
+        val clientSessions = SessionsObject.client
+        var request = chain.request();
+        val interceptUrl = request.url.host
+
+        // No client session found, proceed as is
+        if (clientSessions.isNullOrEmpty() || clientSessions[interceptUrl] !== null) {
+            return chain.proceed(request)
+        }
+
+        // Set our client session
+        var client = clientSessions[interceptUrl]!!;
+
+        // Execute request
+        return client.build().newCall(request).execute()
+    }
+
+}

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/PinnedCertificateInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/PinnedCertificateInterceptor.kt
@@ -1,0 +1,23 @@
+package com.mattermost.networkclient.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import java.io.IOException
+import java.net.InetAddress
+
+
+class PinnedCertificateInterceptor(private val pinnedCert: String, private val pinnedHost: String) : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request();
+        val call = chain.call();
+        val connection = chain.connection()
+
+
+        return chain.proceed(request)
+    }
+
+}

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/PinnedCertificateInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/PinnedCertificateInterceptor.kt
@@ -16,7 +16,6 @@ class PinnedCertificateInterceptor(private val pinnedCert: String, private val p
         val call = chain.call();
         val connection = chain.connection()
 
-
         return chain.proceed(request)
     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -204,6 +204,7 @@ dependencies {
     }
 
     implementation project(':mattermost.networkclient')
+    implementation 'com.quinn.hunter:hunter-okhttp-library:0.8.5'
 }
 
 // Run this once to be able to run the application with BUCK
@@ -214,3 +215,4 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply plugin: 'hunter-okhttp'

--- a/example/android/app/src/main/java/com/example/reactnativenetworkclient/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/reactnativenetworkclient/MainActivity.java
@@ -1,6 +1,10 @@
 package com.example.reactnativenetworkclient;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
+import com.hunter.library.okhttp.OkHttpHooker;
+import com.mattermost.networkclient.interceptors.GlobalInterceptor;
 
 public class MainActivity extends ReactActivity {
 
@@ -12,4 +16,11 @@ public class MainActivity extends ReactActivity {
   protected String getMainComponentName() {
     return "NetworkClientExample";
   }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    OkHttpHooker.installInterceptor(new GlobalInterceptor());
+  }
+
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -12,10 +12,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath('com.android.tools.build:gradle:4.1.2')
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        classpath 'com.quinn.hunter:hunter-okhttp-plugin:1.1.0'
+        classpath 'com.quinn.hunter:hunter-transform:1.1.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Feb 02 10:27:10 AEDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
This is my first pass at introducing TLS certificates to the OkHttp3 client, and then using a global interceptor that replaces any OkHttp3 requests with our client if the base url's match.

Things to note for swizzling:

- Hunter library is installed in the example app, and calls the GlobalInterceptor from the package
- Native Network package now uses a singleton for making the client session objects and requests available across the package
- Global Interceptor calls this singleton to get client session

^^ This is still a bit finicky at the moment, I may have to use delegates I think

Things to note for tls certificates:

- Certificates are expected as PEM strings from the JS side
- Certificates are only attached to the client session (not globally!)
- Because of the above, the global interceptor then looks at the request before replacing the previous client with our own
- Certificate pinning also only works on a given client session

^^ I haven't tested this yet, currently still working through the swizzling.

I also had to update gradle in the example app so that the hunter library would work