### PR TITLE
MM-32242 Detox E2E: Add iOS e2e for create API client

### DIFF
--- a/example/MOCKSERVER.md
+++ b/example/MOCKSERVER.md
@@ -42,6 +42,7 @@ Options:
 | headers | request headers | `curl -i -H "Accept: application/json" -H "Content-Type: application/json" http://host/path` |
 | body | request body | `curl -i -d "key1=value1&key2=value2" http://host/path` |
 | response status | request header for assigning response status | `curl -i -H "response-status: 404 Not Found" http://host/path` |
+
 Example response:
 ```
 HTTP/1.1 200 OK
@@ -64,6 +65,7 @@ server: mock-server
 
 ### Get Request
 Base Path: `/get`
+
 Example:
 ```
 curl -X GET -H "Content-Type: application/json" http://localhost:8080/get
@@ -71,6 +73,7 @@ curl -X GET -H "Content-Type: application/json" http://localhost:8080/get
 
 ### Post Request
 Base Path: `/post`
+
 Example:
 ```
 curl -X POST -d "{\"name\":\"John Doe\",\"phone\":\"333-333-3333\"}" -H "Content-Type: application/json" http://localhost:8080/post
@@ -78,6 +81,7 @@ curl -X POST -d "{\"name\":\"John Doe\",\"phone\":\"333-333-3333\"}" -H "Content
 
 ### Put Request
 Base Path: `/put`
+
 Example:
 ```
 curl -X PUT -d "{\"name\":\"John Doe\",\"phone\":\"444-444-4444\"}" -H "Content-Type: application/json" http://localhost:8080/put
@@ -85,6 +89,7 @@ curl -X PUT -d "{\"name\":\"John Doe\",\"phone\":\"444-444-4444\"}" -H "Content-
 
 ### Patch Request
 Base Path: `/patch`
+
 Example:
 ```
 curl -X PATCH -d "{\"phone\":\"555-555-5555\"}" -H "Content-Type: application/json" http://localhost:8080/patch
@@ -92,6 +97,7 @@ curl -X PATCH -d "{\"phone\":\"555-555-5555\"}" -H "Content-Type: application/js
 
 ### Delete Request
 Base Path: `/delete`
+
 Example:
 ```
 curl -X DELETE -d "{\"permanent\":true}" -H "Content-Type: application/json" http://localhost:8080/delete

--- a/example/README.md
+++ b/example/README.md
@@ -27,6 +27,7 @@ rm -rf node_modules
 npm install
 ```
 2. Install the example application to simulator/emulator device.
+
 iOS,
 ```
 cd ios
@@ -54,6 +55,7 @@ cd ..
 npm run start
 ```
 4. Run detox tests.
+
 iOS,
 ```
 cd detox

--- a/example/detox/e2e/support/ui/component/alert.js
+++ b/example/detox/e2e/support/ui/component/alert.js
@@ -5,6 +5,7 @@ import {isAndroid} from '@support/utils';
 
 class Alert {
     // alert titles
+    errorTitle = isAndroid() ? element(by.text('Error')) : element(by.label('Error')).atIndex(0);
     removeClientTitle = isAndroid() ? element(by.text('Remove Client')) : element(by.label('Remove Client')).atIndex(0);
 
     // alert buttons

--- a/example/detox/e2e/support/ui/component/retry_policy_configuration.js
+++ b/example/detox/e2e/support/ui/component/retry_policy_configuration.js
@@ -10,13 +10,15 @@ class RetryPolicyConfiguration {
         exponentialBackoffScaleInput: 'retry_policy_configuration.exponential_backoff_scale.input',
     }
 
-    retryCheckbox = element(by.text('Retries with exponential backoff?'));
+    retryCheckboxFalse = element(by.text('Retries with exponential backoff? false'));
+    retryCheckboxTrue = element(by.text('Retries with exponential backoff? true'));
     retryLimitInput = element(by.id(this.testID.retryLimitInput));
     exponentialBackoffBaseInput = element(by.id(this.testID.exponentialBackoffBaseInput));
     exponentialBackoffScaleInput = element(by.id(this.testID.exponentialBackoffScaleInput));
 
     setRetry = async ({retryLimit = '2', exponentialBackoffBase = '2', exponentialBackoffScale = '0.5'}) => {
-        await this.retryCheckbox.tap();
+        // # Toggle on retry checkbox
+        await this.toggleOnRetryCheckbox();
 
         // # Set retry limit
         await this.retryLimitInput.clearText();
@@ -43,6 +45,16 @@ class RetryPolicyConfiguration {
             await expect(this.exponentialBackoffBaseInput).toHaveValue(exponentialBackoffBase);
             await expect(this.exponentialBackoffScaleInput).toHaveValue(exponentialBackoffScale);
         }
+    }
+
+    toggleOffRetryCheckbox = async () => {
+        await this.retryCheckboxTrue.tap();
+        await expect(this.retryCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnRetryCheckbox = async () => {
+        await this.retryCheckboxFalse.tap();
+        await expect(this.retryCheckboxTrue).toBeVisible();
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/api_client.js
+++ b/example/detox/e2e/support/ui/screen/api_client.js
@@ -26,7 +26,7 @@ class ApiClientScreen {
     postButton = MethodButtons.postButton;
     putButton = MethodButtons.putButton;
 
-    getHeaderListItemAtIndex = async (index) => {
+    getHeaderListItemAtIndex = (index) => {
         return HeaderListItem.getItemAtIndex(index);
     }
 

--- a/example/detox/e2e/support/ui/screen/client_list.js
+++ b/example/detox/e2e/support/ui/screen/client_list.js
@@ -16,11 +16,14 @@ class ClientListScreen {
     }
 
     removeClientWithName = async (name) => {
+        const {
+            okButton,
+            removeClientTitle,
+        } = Alert;
+
         await element(by.text(name)).longPress();
-        const {okButton, removeClientTitle} = Alert;
-        await removeClientTitle.toBeVisible();
+        await expect(removeClientTitle).toBeVisible();
         await okButton.tap();
-        await element(by.text(name)).not.toBeVisible();
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/create_api_client.js
+++ b/example/detox/e2e/support/ui/screen/create_api_client.js
@@ -9,6 +9,7 @@ import {ClientListScreen} from '@support/ui/screen';
 
 class CreateApiClientScreen {
     testID = {
+        createApiClientScrollView: 'create_api_client.scroll_view',
         baseUrlInput: 'create_api_client.base_url.input',
         bearerAuthTokenInput: 'create_api_client.bearer_auth_token.input',
         nameInput: 'create_api_client.name.input',
@@ -18,21 +19,27 @@ class CreateApiClientScreen {
     }
 
     createApiClientScreen = element(by.text('CreateAPIClient'));
+    createApiClientScrollView = element(by.id(this.testID.createApiClientScrollView));
     baseUrlInput = element(by.id(this.testID.baseUrlInput));
     bearerAuthTokenInput = element(by.id(this.testID.bearerAuthTokenInput));
     maxConnectionsInput = element(by.id(this.testID.maxConnectionsInput));
     nameInput = element(by.id(this.testID.nameInput));
     requestTimeoutIntervalInput = element(by.id(this.testID.requestTimeoutIntervalInput));
     resourceTimeoutIntervalInput = element(by.id(this.testID.resourceTimeoutIntervalInput));
-    allowCellularAccessCheckbox = element(by.text('Allow Cellular Access?'));
-    cancelRequestsOn401Checkbox = element(by.text('Cancel Requests On 401?'));
-    followRedirectsCheckbox = element(by.text('Follow Redirects?'));
-    waitsForConnectivityCheckbox = element(by.text('Waits For Connectivity?'));
+    allowCellularAccessCheckboxFalse = element(by.text('Allow Cellular Access? false'));
+    allowCellularAccessCheckboxTrue = element(by.text('Allow Cellular Access? true'));
+    cancelRequestsOn401CheckboxFalse = element(by.text('Cancel Requests On 401? false'));
+    cancelRequestsOn401CheckboxTrue = element(by.text('Cancel Requests On 401? true'));
+    followRedirectsCheckboxFalse = element(by.text('Follow Redirects? false'));
+    followRedirectsCheckboxTrue = element(by.text('Follow Redirects? true'));
+    waitsForConnectivityCheckboxFalse = element(by.text('Waits For Connectivity? false'));
+    waitsForConnectivityCheckboxTrue = element(by.text('Waits For Connectivity? true'));
     clientListButton = element(by.text('ClientList')).atIndex(0);
     createButton = element(by.text('Create'));
 
     // convenience props
-    retryCheckbox = RetryPolicyConfiguration.retryCheckbox;
+    toggleOffRetryCheckbox = RetryPolicyConfiguration.toggleOffRetryCheckbox;
+    toggleOnRetryCheckbox = RetryPolicyConfiguration.toggleOnRetryCheckbox;
     retryLimitInput = RetryPolicyConfiguration.retryLimitInput;
     exponentialBackoffBaseInput = RetryPolicyConfiguration.exponentialBackoffBaseInput;
     exponentialBackoffScaleInput = RetryPolicyConfiguration.exponentialBackoffScaleInput;
@@ -53,6 +60,10 @@ class CreateApiClientScreen {
     back = async () => {
         await this.clientListButton.tap();
         await expect(this.createApiClientScreen).not.toBeVisible();
+    }
+
+    createClient = async () => {
+        await this.createButton.tap();
     }
 
     setBaseUrl = async (url) => {
@@ -93,6 +104,50 @@ class CreateApiClientScreen {
         await this.resourceTimeoutIntervalInput.clearText();
         await this.resourceTimeoutIntervalInput.replaceText(resourceTimeoutInterval);
         await this.resourceTimeoutIntervalInput.tapReturnKey();
+    }
+
+    setRetry = async (options = {retryLimit: '2', exponentialBackoffBase: '2', exponentialBackoffScale: '0.5'}) => {
+        await RetryPolicyConfiguration.setRetry(options);
+    }
+
+    toggleOffAllowCellularAccessCheckbox = async () => {
+        await this.allowCellularAccessCheckboxTrue.tap();
+        await expect(this.allowCellularAccessCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnAllowCellularAccessCheckbox = async () => {
+        await this.allowCellularAccessCheckboxFalse.tap();
+        await expect(this.allowCellularAccessCheckboxTrue).toBeVisible();
+    }
+
+    toggleOffCancelRequestsOn401Checkbox = async () => {
+        await this.cancelRequestsOn401CheckboxTrue.tap();
+        await expect(this.cancelRequestsOn401CheckboxFalse).toBeVisible();
+    }
+
+    toggleOnCancelRequestsOn401Checkbox = async () => {
+        await this.cancelRequestsOn401CheckboxFalse.tap();
+        await expect(this.cancelRequestsOn401CheckboxTrue).toBeVisible();
+    }
+
+    toggleOffFollowRedirectsCheckbox = async () => {
+        await this.followRedirectsCheckboxTrue.tap();
+        await expect(this.followRedirectsCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnFollowRedirectsCheckbox = async () => {
+        await this.followRedirectsCheckboxFalse.tap();
+        await expect(this.followRedirectsCheckboxTrue).toBeVisible();
+    }
+
+    toggleOffWaitsForConnectivityCheckbox = async () => {
+        await this.waitsForConnectivityCheckboxTrue.tap();
+        await expect(this.waitsForConnectivityCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnWaitsForConnectivityCheckbox = async () => {
+        await this.waitsForConnectivityCheckboxFalse.tap();
+        await expect(this.waitsForConnectivityCheckboxTrue).toBeVisible();
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/create_web_socket_client.js
+++ b/example/detox/e2e/support/ui/screen/create_web_socket_client.js
@@ -5,6 +5,12 @@ import {ClientListScreen} from '@support/ui/screen';
 
 class CreateWebSocketClientScreen {
     createWebSocketClientScreen = element(by.text('CreateWebSocketClient'));
+    allowSelfSignedCertificatesCheckboxFalse = element(by.text('Allow Self Signed Certificates? false'));
+    allowSelfSignedCertificatesCheckboxTrue = element(by.text('Allow Self Signed Certificates? true'));
+    enableCompressionCheckboxFalse = element(by.text('Enable Compression? false'));
+    enableCompressionCheckboxTrue = element(by.text('Enable Compression? true'));
+    enableSslPinningCheckboxFalse = element(by.text('Enable SSL Pinning? false'));
+    enableSslPinningCheckboxTrue = element(by.text('Enable SSL Pinning? true'));
     clientListButton = element(by.text('ClientList')).atIndex(0);
     createButton = element(by.text('Create'));
 
@@ -24,6 +30,36 @@ class CreateWebSocketClientScreen {
     back = async () => {
         await this.clientListButton.tap();
         await expect(this.createWebSocketClientScreen).not.toBeVisible();
+    }
+
+    toggleOffAllowSelfSignedCertificatesCheckbox = async () => {
+        await this.allowSelfSignedCertificatesCheckboxTrue.tap();
+        await expect(this.allowSelfSignedCertificatesCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnAllowSelfSignedCertificatesCheckbox = async () => {
+        await this.allowSelfSignedCertificatesCheckboxFalse.tap();
+        await expect(this.allowSelfSignedCertificatesCheckboxTrue).toBeVisible();
+    }
+
+    toggleOffEnableCompressionCheckbox = async () => {
+        await this.enableCompressionCheckboxTrue.tap();
+        await expect(this.enableCompressionCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnEnableCompressionCheckbox = async () => {
+        await this.enableCompressionCheckboxFalse.tap();
+        await expect(this.enableCompressionCheckboxTrue).toBeVisible();
+    }
+
+    toggleOffEnableSslPinningCheckbox = async () => {
+        await this.enableSslPinningCheckboxTrue.tap();
+        await expect(this.enableSslPinningCheckboxFalse).toBeVisible();
+    }
+
+    toggleOnEnableSslPinningCheckbox = async () => {
+        await this.enableSslPinningCheckboxFalse.tap();
+        await expect(this.enableSslPinningCheckboxTrue).toBeVisible();
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/generic_client_request.js
+++ b/example/detox/e2e/support/ui/screen/generic_client_request.js
@@ -29,7 +29,8 @@ class GenericClientRequestScreen {
     patchButton = MethodButtons.patchButton;
     postButton = MethodButtons.postButton;
     putButton = MethodButtons.putButton;
-    retryCheckbox = RetryPolicyConfiguration.retryCheckbox;
+    toggleOffRetryCheckbox = RetryPolicyConfiguration.toggleOffRetryCheckbox;
+    toggleOnRetryCheckbox = RetryPolicyConfiguration.toggleOnRetryCheckbox;
     retryLimitInput = RetryPolicyConfiguration.retryLimitInput;
     exponentialBackoffBaseInput = RetryPolicyConfiguration.exponentialBackoffBaseInput;
     exponentialBackoffScaleInput = RetryPolicyConfiguration.exponentialBackoffScaleInput;

--- a/example/detox/e2e/support/utils.js
+++ b/example/detox/e2e/support/utils.js
@@ -40,6 +40,15 @@ export const getRandomId = (length = 6) => {
 };
 
 /**
+ * Get random integer.
+ * @param {number} max - max number exclusive, e.g. 10 (default), expected 0 - 9
+ * @return {number} random integer
+ */
+export const getRandomInt = (max = 10) => {
+    return Math.floor(Math.random() * Math.floor(max));
+}
+
+/**
  * Capitalize first character of text.
  * @param {string} text
  * @return {string} capitalized text

--- a/example/detox/e2e/test/client/create_api_client.e2e.js
+++ b/example/detox/e2e/test/client/create_api_client.e2e.js
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import {Alert} from '@support/ui/component';
+import {
+    ApiClientScreen,
+    ClientListScreen,
+    CreateApiClientScreen,
+} from '@support/ui/screen';
+import {
+    getRandomId,
+    getRandomInt,
+} from '@support/utils';
+import {
+    customHeaders,
+    verifyApiClient,
+} from '../helpers';
+
+describe('Create API Client', () => {
+    const randomText = getRandomId(10);
+    const testBaseUrl = `https://example-${randomText}-api.com`;
+    const testName = `Example ${randomText} API`;
+    const testHeaders = {...customHeaders};
+    const testToken = getRandomId(10);
+    const testRequestTimeoutInterval = getRandomInt(60).toString();
+    const testResourceTimeoutInterval = getRandomInt(60).toString();
+    const testMaxConnections = getRandomInt(10).toString();
+    const testRetry = {
+        retryLimit: `${getRandomInt(5) + 1}`,
+        exponentialBackoffBase: `${getRandomInt(5) + 2}`,
+        exponentialBackoffScale: `${getRandomInt(5) + 3}`,
+    };
+    const {
+        createApiClientScrollView,
+        createClient,
+        setBaseUrl,
+        setBearerAuthToken,
+        setHeaders,
+        setMaxConnections,
+        setName,
+        setRequestTimeoutInterval,
+        setResourceTimeoutInterval,
+        setRetry,
+        toggleOnCancelRequestsOn401Checkbox,
+        toggleOnWaitsForConnectivityCheckbox,
+    } = CreateApiClientScreen;
+
+    beforeAll(async () => {
+        await CreateApiClientScreen.open();
+    });
+
+    it('should be able to create an API client', async () => {
+        // # Set all fields and create client
+        await setName(testName);
+        await setBaseUrl(testBaseUrl);
+        await setHeaders(testHeaders);
+        await setBearerAuthToken(testToken);
+        await setRequestTimeoutInterval(testRequestTimeoutInterval);
+        await setResourceTimeoutInterval(testResourceTimeoutInterval);
+        await setMaxConnections(testMaxConnections);
+        await createApiClientScrollView.scrollTo('bottom');
+        await setRetry(testRetry);
+        await createApiClientScrollView.scrollTo('bottom');
+        await toggleOnWaitsForConnectivityCheckbox();
+        await toggleOnCancelRequestsOn401Checkbox();
+        await createClient();
+
+        // * Verify created client
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, testHeaders);
+
+        // # Open client list screen
+        await ApiClientScreen.back();
+    });
+
+    it('should not be able to create an API client with existing URL', async () => {
+        const {
+            errorTitle,
+            okButton,
+        } = Alert;
+
+        // # Open create API client screen
+        await CreateApiClientScreen.open();
+
+        // # Set an existing url and attempt to create client
+        await setBaseUrl(testBaseUrl);
+        await createApiClientScrollView.scrollTo('bottom');
+        await createClient();
+
+        // * Verify error alert
+        await expect(errorTitle).toBeVisible();
+        await expect(element(by.text(`A client for ${testBaseUrl} already exists`))).toBeVisible();
+        await okButton.tap();
+        await CreateApiClientScreen.toBeVisible();
+
+        // # Open client list screen
+        await CreateApiClientScreen.back();
+    });
+
+    it('should be able to remove an API client', async () => {
+        // # Remove client
+        await ClientListScreen.removeClientWithName(testName);
+
+        // * Verify client is removed
+        await expect(element(by.text(testName))).not.toBeVisible();
+    });
+});

--- a/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
@@ -8,13 +8,18 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {ApiClientScreen} from '@support/ui/screen';
 import {
     customBody,
     customHeaders,
     newHeaders,
     performApiClientRequest,
+    verifyApiClient,
     verifyApiResponse,
     verifyResponseOverlay,
 } from '../helpers';
@@ -22,10 +27,12 @@ import {
 describe('Delete - API Client Request', () => {
     const testMethod = 'DELETE';
     const testPath = `/${testMethod.toLowerCase()}`;
-    const testServerUrl = `${testConfig.serverUrl}${testPath}`;
-    const testSiteUrl = `${testConfig.siteUrl}${testPath}`;
-    const testHost = testConfig.host;
+    const testBaseUrl = serverUrl;
+    const testServerUrl = `${testBaseUrl}${testPath}`;
+    const testSiteUrl = `${siteUrl}${testPath}`;
+    const testHost = host;
     const testStatus = 200;
+    const testName = 'Mockserver API';
     const testHeaders = {...newHeaders};
     const testBody = {...customBody};
     const combinedHeaders = {
@@ -37,7 +44,8 @@ describe('Delete - API Client Request', () => {
         const apiResponse = await Request.apiDelete({headers: testHeaders, body: testBody});
         await verifyApiResponse(apiResponse, testSiteUrl, testStatus, testHost, testMethod, testHeaders, testBody);
 
-        await ApiClientScreen.open('Mockserver API');
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, customHeaders);
         await ApiClientScreen.deleteButton.tap();
     });
 

--- a/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
@@ -8,7 +8,11 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {GenericClientRequestScreen} from '@support/ui/screen';
 import {
     customBody,
@@ -20,9 +24,9 @@ import {
 
 describe('Delete - Generic Client Request', () => {
     const testMethod = 'DELETE';
-    const testServerUrl = `${testConfig.serverUrl}/${testMethod.toLowerCase()}`;
-    const testSiteUrl = `${testConfig.siteUrl}/${testMethod.toLowerCase()}`;
-    const testHost = testConfig.host;
+    const testServerUrl = `${serverUrl}/${testMethod.toLowerCase()}`;
+    const testSiteUrl = `${siteUrl}/${testMethod.toLowerCase()}`;
+    const testHost = host;
     const testStatus = 200;
     const testHeaders = {...customHeaders};
     const testBody = {...customBody};

--- a/example/detox/e2e/test/get/get_api_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_api_client_request.e2e.js
@@ -8,12 +8,17 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {ApiClientScreen} from '@support/ui/screen';
 import {
     customHeaders,
     newHeaders,
     performApiClientRequest,
+    verifyApiClient,
     verifyApiResponse,
     verifyResponseOverlay,
 } from '../helpers';
@@ -21,10 +26,12 @@ import {
 describe('Get - API Client Request', () => {
     const testMethod = 'GET';
     const testPath = `/${testMethod.toLowerCase()}`;
-    const testServerUrl = `${testConfig.serverUrl}${testPath}`;
-    const testSiteUrl = `${testConfig.siteUrl}${testPath}`;
-    const testHost = testConfig.host;
+    const testBaseUrl = serverUrl;
+    const testServerUrl = `${testBaseUrl}${testPath}`;
+    const testSiteUrl = `${siteUrl}${testPath}`;
+    const testHost = host;
     const testStatus = 200;
+    const testName = 'Mockserver API';
     const testHeaders = {...newHeaders};
     const combinedHeaders = {
         ...customHeaders,
@@ -35,7 +42,8 @@ describe('Get - API Client Request', () => {
         const apiResponse = await Request.apiGet({headers: testHeaders});
         await verifyApiResponse(apiResponse, testSiteUrl, testStatus, testHost, testMethod, testHeaders);
 
-        await ApiClientScreen.open('Mockserver API');
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, customHeaders);
         await ApiClientScreen.getButton.tap();
     });
 

--- a/example/detox/e2e/test/get/get_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_generic_client_request.e2e.js
@@ -8,7 +8,11 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {GenericClientRequestScreen} from '@support/ui/screen';
 import {
     customHeaders,
@@ -19,9 +23,9 @@ import {
 
 describe('Get - Generic Client Request', () => {
     const testMethod = 'GET';
-    const testServerUrl = `${testConfig.serverUrl}/${testMethod.toLowerCase()}`;
-    const testSiteUrl = `${testConfig.siteUrl}/${testMethod.toLowerCase()}`;
-    const testHost = testConfig.host;
+    const testServerUrl = `${serverUrl}/${testMethod.toLowerCase()}`;
+    const testSiteUrl = `${siteUrl}/${testMethod.toLowerCase()}`;
+    const testHost = host;
     const testStatus = 200;
     const testHeaders = {...customHeaders};
 

--- a/example/detox/e2e/test/helpers.js
+++ b/example/detox/e2e/test/helpers.js
@@ -5,21 +5,25 @@ import jestExpect from 'expect';
 
 import {
     ApiClientRequestScreen,
+    ApiClientScreen,
     GenericClientRequestScreen,
 } from '@support/ui/screen';
-import {isIos} from '@support/utils';
+import {
+    isAndroid,
+    isIos,
+} from '@support/utils';
 
 export const customHeaders = {
-    'custom-header-1-key': 'custom-header-1-value',
-    'custom-header-2-key': 'custom-header-2-value',
+    'header-1-key': 'header-1-value',
+    'header-2-key': 'header-2-value',
 };
 export const newHeaders = {
     'new-header-1-key': 'new-header-1-value',
     'new-header-2-key': 'new-header-2-value',
 };
 export const customBody = {
-    'customField1key': 'customField1value',
-    'customField2key': 'customField2value',
+    'field1key': 'field1value',
+    'field2key': 'field2value',
 };
 
 /**
@@ -176,6 +180,39 @@ export const verifyResponseOverlay = async (testUrl, testStatus, testHost, testM
             for (const [k, v] of Object.entries(testBody)) {
                 jestExpect(responseDataRequest.body[k]).toBe(v);
             }
+        }
+    }
+};
+
+export const verifyApiClient = async (testName, testUrl, testHeaders) => {
+    const {
+        baseUrlInput,
+        getHeaderListItemAtIndex,
+        nameInput,
+    } = ApiClientScreen;
+
+    const ordered = Object.keys(testHeaders).sort().reduce((result, key) => {
+        result[key] = testHeaders[key];
+        return result;
+    }, {});
+    const entries = Object.entries(ordered);
+    if (isAndroid()) {
+        await expect(nameInput).toHaveText(testName);
+        await expect(baseUrlInput).toHaveText(testUrl);
+
+        for (const [index, [key, value]] of Object.entries(entries)) {
+            const {keyInput, valueInput} = getHeaderListItemAtIndex(index);
+            await expect(keyInput).toHaveText(key);
+            await expect(valueInput).toHaveText(value);
+        }
+    } else {
+        await expect(nameInput).toHaveValue(testName);
+        await expect(baseUrlInput).toHaveValue(testUrl);
+
+        for (const [index, [key, value]] of Object.entries(entries)) {
+            const {keyInput, valueInput} = getHeaderListItemAtIndex(index);
+            await expect(keyInput).toHaveValue(key);
+            await expect(valueInput).toHaveValue(value);
         }
     }
 };

--- a/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
@@ -8,13 +8,18 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {ApiClientScreen} from '@support/ui/screen';
 import {
     customBody,
     customHeaders,
     newHeaders,
     performApiClientRequest,
+    verifyApiClient,
     verifyApiResponse,
     verifyResponseOverlay,
 } from '../helpers';
@@ -22,10 +27,12 @@ import {
 describe('Patch - API Client Request', () => {
     const testMethod = 'PATCH';
     const testPath = `/${testMethod.toLowerCase()}`;
-    const testServerUrl = `${testConfig.serverUrl}${testPath}`;
-    const testSiteUrl = `${testConfig.siteUrl}${testPath}`;
-    const testHost = testConfig.host;
+    const testBaseUrl = serverUrl;
+    const testServerUrl = `${testBaseUrl}${testPath}`;
+    const testSiteUrl = `${siteUrl}${testPath}`;
+    const testHost = host;
     const testStatus = 200;
+    const testName = 'Mockserver API';
     const testHeaders = {...newHeaders};
     const testBody = {...customBody};
     const combinedHeaders = {
@@ -37,7 +44,8 @@ describe('Patch - API Client Request', () => {
         const apiResponse = await Request.apiPatch({headers: testHeaders, body: testBody});
         await verifyApiResponse(apiResponse, testSiteUrl, testStatus, testHost, testMethod, testHeaders, testBody);
 
-        await ApiClientScreen.open('Mockserver API');
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, customHeaders);
         await ApiClientScreen.patchButton.tap();
     });
 

--- a/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
@@ -8,7 +8,11 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {GenericClientRequestScreen} from '@support/ui/screen';
 import {
     customBody,
@@ -20,9 +24,9 @@ import {
 
 describe('Patch - Generic Client Request', () => {
     const testMethod = 'PATCH';
-    const testServerUrl = `${testConfig.serverUrl}/${testMethod.toLowerCase()}`;
-    const testSiteUrl = `${testConfig.siteUrl}/${testMethod.toLowerCase()}`;
-    const testHost = testConfig.host;
+    const testServerUrl = `${serverUrl}/${testMethod.toLowerCase()}`;
+    const testSiteUrl = `${siteUrl}/${testMethod.toLowerCase()}`;
+    const testHost = host;
     const testStatus = 200;
     const testHeaders = {...customHeaders};
     const testBody = {...customBody};

--- a/example/detox/e2e/test/post/post_api_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_api_client_request.e2e.js
@@ -8,13 +8,18 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {ApiClientScreen} from '@support/ui/screen';
 import {
     customBody,
     customHeaders,
     newHeaders,
     performApiClientRequest,
+    verifyApiClient,
     verifyApiResponse,
     verifyResponseOverlay,
 } from '../helpers';
@@ -22,10 +27,12 @@ import {
 describe('Post - API Client Request', () => {
     const testMethod = 'POST';
     const testPath = `/${testMethod.toLowerCase()}`;
-    const testServerUrl = `${testConfig.serverUrl}${testPath}`;
-    const testSiteUrl = `${testConfig.siteUrl}${testPath}`;
-    const testHost = testConfig.host;
+    const testBaseUrl = serverUrl;
+    const testServerUrl = `${testBaseUrl}${testPath}`;
+    const testSiteUrl = `${siteUrl}${testPath}`;
+    const testHost = host;
     const testStatus = 200;
+    const testName = 'Mockserver API';
     const testHeaders = {...newHeaders};
     const testBody = {...customBody};
     const combinedHeaders = {
@@ -37,7 +44,8 @@ describe('Post - API Client Request', () => {
         const apiResponse = await Request.apiPost({headers: testHeaders, body: testBody});
         await verifyApiResponse(apiResponse, testSiteUrl, testStatus, testHost, testMethod, testHeaders, testBody);
 
-        await ApiClientScreen.open('Mockserver API');
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, customHeaders);
         await ApiClientScreen.postButton.tap();
     });
 

--- a/example/detox/e2e/test/post/post_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_generic_client_request.e2e.js
@@ -8,7 +8,11 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {GenericClientRequestScreen} from '@support/ui/screen';
 import {
     customBody,
@@ -20,9 +24,9 @@ import {
 
 describe('Post - Generic Client Request', () => {
     const testMethod = 'POST';
-    const testServerUrl = `${testConfig.serverUrl}/${testMethod.toLowerCase()}`;
-    const testSiteUrl = `${testConfig.siteUrl}/${testMethod.toLowerCase()}`;
-    const testHost = testConfig.host;
+    const testServerUrl = `${serverUrl}/${testMethod.toLowerCase()}`;
+    const testSiteUrl = `${siteUrl}/${testMethod.toLowerCase()}`;
+    const testHost = host;
     const testStatus = 200;
     const testHeaders = {...customHeaders};
     const testBody = {...customBody};

--- a/example/detox/e2e/test/put/put_api_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_api_client_request.e2e.js
@@ -8,13 +8,18 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {ApiClientScreen} from '@support/ui/screen';
 import {
     customBody,
     customHeaders,
     newHeaders,
     performApiClientRequest,
+    verifyApiClient,
     verifyApiResponse,
     verifyResponseOverlay,
 } from '../helpers';
@@ -22,10 +27,12 @@ import {
 describe('Put - API Client Request', () => {
     const testMethod = 'PUT';
     const testPath = `/${testMethod.toLowerCase()}`;
-    const testServerUrl = `${testConfig.serverUrl}${testPath}`;
-    const testSiteUrl = `${testConfig.siteUrl}${testPath}`;
-    const testHost = testConfig.host;
+    const testBaseUrl = serverUrl;
+    const testServerUrl = `${testBaseUrl}${testPath}`;
+    const testSiteUrl = `${siteUrl}${testPath}`;
+    const testHost = host;
     const testStatus = 200;
+    const testName = 'Mockserver API';
     const testHeaders = {...newHeaders};
     const testBody = {...customBody};
     const combinedHeaders = {
@@ -37,7 +44,8 @@ describe('Put - API Client Request', () => {
         const apiResponse = await Request.apiPut({headers: testHeaders, body: testBody});
         await verifyApiResponse(apiResponse, testSiteUrl, testStatus, testHost, testMethod, testHeaders, testBody);
 
-        await ApiClientScreen.open('Mockserver API');
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, customHeaders);
         await ApiClientScreen.putButton.tap();
     });
 

--- a/example/detox/e2e/test/put/put_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_generic_client_request.e2e.js
@@ -8,7 +8,11 @@
 // *******************************************************************
 
 import {Request} from '@support/server_api';
-import testConfig from '@support/test_config';
+import {
+    host,
+    siteUrl,
+    serverUrl,
+} from '@support/test_config';
 import {GenericClientRequestScreen} from '@support/ui/screen';
 import {
     customBody,
@@ -20,9 +24,9 @@ import {
 
 describe('Put - Generic Client Request', () => {
     const testMethod = 'PUT';
-    const testServerUrl = `${testConfig.serverUrl}/${testMethod.toLowerCase()}`;
-    const testSiteUrl = `${testConfig.siteUrl}/${testMethod.toLowerCase()}`;
-    const testHost = testConfig.host;
+    const testServerUrl = `${serverUrl}/${testMethod.toLowerCase()}`;
+    const testSiteUrl = `${siteUrl}/${testMethod.toLowerCase()}`;
+    const testHost = host;
     const testStatus = 200;
     const testHeaders = {...customHeaders};
     const testBody = {...customBody};

--- a/example/src/components/RetryPolicyConfiguration.tsx
+++ b/example/src/components/RetryPolicyConfiguration.tsx
@@ -17,7 +17,7 @@ interface RetryPolicyConfigurationProps extends RetryPolicyConfiguration {
 const RetryPolicyConfiguration = (props: RetryPolicyConfigurationProps) => (
     <>
         <CheckBox
-            title="Retries with exponential backoff?"
+            title={`Retries with exponential backoff? ${props.checked}`}
             checked={props.checked}
             onPress={props.onCheckBoxPress}
             iconType="ionicon"

--- a/example/src/screens/APIClientScreen.tsx
+++ b/example/src/screens/APIClientScreen.tsx
@@ -82,21 +82,31 @@ export default function APIClientScreen({
 
     useEffect(() => {
         client.getHeaders().then((clientHeaders) => {
-            const headers = Object.entries(
-                clientHeaders
+            const ordered = Object.keys(clientHeaders).sort().reduce((result: Record<string, string>, key) => {
+                result[key] = clientHeaders[key];
+                return result;
+            }, {});
+            const orderedHeaders = Object.entries(
+                ordered
             ).map(([key, value]) => ({ key, value }));
-            setHeaders(headers);
+            setHeaders(orderedHeaders);
         });
     }, []);
 
     return (
         <SafeAreaView>
             <ScrollView>
-                <Input label="Name" value={name} disabled={true} />
+                <Input
+                    label="Name"
+                    value={name}
+                    disabled={true}
+                    testID='api_client.name.input'
+                />
                 <Input
                     label="Base URL"
                     value={client.baseUrl}
                     disabled={true}
+                    testID='api_client.base_url.input'
                 />
                 <ListHeaders headers={headers} />
                 <Buttons />

--- a/example/src/screens/CreateAPIClientScreen.tsx
+++ b/example/src/screens/CreateAPIClientScreen.tsx
@@ -91,7 +91,7 @@ export default function CreateAPIClientScreen({
 
     return (
         <SafeAreaView>
-            <ScrollView>
+            <ScrollView testID='create_api_client.scroll_view'>
                 <Input
                     label="Name"
                     onChangeText={setName}
@@ -135,7 +135,7 @@ export default function CreateAPIClientScreen({
                     value={sessionConfiguration.httpMaximumConnectionsPerHost}
                     onChange={setHttpMaximumConnectionsPerHost}
                     minValue={1}
-                    testID='create_api_client.max_connects.input'
+                    testID='create_api_client.max_connections.input'
                 />
 
                 <RetryPolicyConfiguration
@@ -154,8 +154,10 @@ export default function CreateAPIClientScreen({
                 />
 
                 <CheckBox
-                    title="Follow Redirects?"
-                    checked={sessionConfiguration.followRedirects as boolean}
+                    title={`Follow Redirects? ${sessionConfiguration.followRedirects}`}
+                    checked={
+                        sessionConfiguration.followRedirects as boolean
+                    }
                     onPress={toggleFollowRedirects}
                     iconType="ionicon"
                     checkedIcon="ios-checkmark-circle"
@@ -165,7 +167,7 @@ export default function CreateAPIClientScreen({
                 />
 
                 <CheckBox
-                    title="Allow Cellular Access?"
+                    title={`Allow Cellular Access? ${sessionConfiguration.allowsCellularAccess}`}
                     checked={
                         sessionConfiguration.allowsCellularAccess as boolean
                     }
@@ -178,7 +180,7 @@ export default function CreateAPIClientScreen({
                 />
 
                 <CheckBox
-                    title="Waits For Connectivity?"
+                    title={`Waits For Connectivity? ${sessionConfiguration.waitsForConnectivity}`}
                     checked={
                         sessionConfiguration.waitsForConnectivity as boolean
                     }
@@ -191,7 +193,7 @@ export default function CreateAPIClientScreen({
                 />
 
                 <CheckBox
-                    title="Cancel Requests On 401?"
+                    title={`Cancel Requests On 401? ${sessionConfiguration.cancelRequestsOnUnauthorized}`}
                     checked={
                         sessionConfiguration.cancelRequestsOnUnauthorized as boolean
                     }

--- a/example/src/screens/CreateWebSocketClientScreen.tsx
+++ b/example/src/screens/CreateWebSocketClientScreen.tsx
@@ -121,7 +121,7 @@ export default function CreateWebSocketClientScreen({
                 />
 
                 <CheckBox
-                    title="Enable Compression?"
+                    title={`Enable Compression? ${configuration.enableCompression!}`}
                     checked={configuration.enableCompression!}
                     onPress={toggleEnableCompression}
                     iconType="ionicon"
@@ -132,7 +132,7 @@ export default function CreateWebSocketClientScreen({
                 />
 
                 <CheckBox
-                    title="Enable SSL Pinning?"
+                    title={`Enable SSL Pinning? ${configuration.sslPinningConfiguration!.enabled}`}
                     checked={configuration.sslPinningConfiguration!.enabled}
                     onPress={toggleEnableSSLPinning}
                     iconType="ionicon"
@@ -144,7 +144,7 @@ export default function CreateWebSocketClientScreen({
 
                 {configuration.sslPinningConfiguration!.enabled && (
                     <CheckBox
-                        title="Allow Self Signed Certificates?"
+                        title={`Allow Self Signed Certificates? ${configuration.sslPinningConfiguration!.allowSelfSigned!}`}
                         checked={
                             configuration.sslPinningConfiguration!
                                 .allowSelfSigned!

--- a/example/src/utils/index.tsx
+++ b/example/src/utils/index.tsx
@@ -142,8 +142,8 @@ const createMockserverAPIClient = async (): Promise<APIClientItem | null> => {
     const name = "Mockserver API";
     const baseUrl = Platform.OS === 'ios' ? "http://localhost:8080" : "http://10.0.2.2:8080";
     const headers = {
-        "custom-header-1-key": "custom-header-1-value",
-        "custom-header-2-key": "custom-header-2-value",
+        "header-1-key": "header-1-value",
+        "header-2-key": "header-2-value",
     };
     const configuration = buildDefaultApiClientConfiguration(headers);
 


### PR DESCRIPTION
#### Summary
- Added e2e for create API client `e2e/test/client/create_api_client.e2e.js`
- Added checkbox helper functions on screen objects
- Added API client screen verifications on related E2Es and some cleanup
- Made display of added headers ordered in API client screen
- Fixed formatting on docs

Note: These changes are also for Android. However, since Android app still has issues that prevent e2e testing, I only assigned the iOS ticket to this PR. I will retest on Android once issues have been fixed [MM-32806](https://mattermost.atlassian.net/browse/MM-32806), [MM-32681](https://mattermost.atlassian.net/browse/MM-32681), [MM-32685](https://mattermost.atlassian.net/browse/MM-32685)


#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-32242

![Screen Shot 2021-02-11 at 3 56 32 PM](https://user-images.githubusercontent.com/487991/107716720-da5ede80-6c86-11eb-87a5-7155beb24e18.png)
