### PR TITLE
[MM-32243, MM-32807] Detox/E2E: Sample Android E2E for creating api client, generic and api clients requests

### DIFF
--- a/example/MOCKSERVER.md
+++ b/example/MOCKSERVER.md
@@ -1,15 +1,11 @@
 # Mock Server
 
 ### How to run Mockserver
-1. [Install Mockserver](https://github.com/namshi/mockserver#installation).
-```
-npm install -g mockserver
-```
-2. Run Mockserver
+1. Run Mockserver
 ```
 npm run mockserver
 ```
-3. Verify Mockserver is running: `http://localhost:8080`.
+2. Verify Mockserver is running: `http://localhost:8080`.
 
 ### How to create mocks
 [Mock files](https://github.com/namshi/mockserver#mock-files) follow this convention based on the response that they are going to serve:

--- a/example/detox/e2e/support/ui/component/add_headers.js
+++ b/example/detox/e2e/support/ui/component/add_headers.js
@@ -12,7 +12,7 @@ class AddHeaders {
     addEmptyHeaderButton = element(by.id(this.testID.addEmptyHeaderButton));
 
     getHeaderListItemAtIndex = (index) => {
-        return HeaderListItem.getItemAtIndex(index);
+        return HeaderListItem.getAddHeadersItemAtIndex(index);
     }
 
     setHeader = async (index, key, value) => {

--- a/example/detox/e2e/support/ui/component/header_list_item.js
+++ b/example/detox/e2e/support/ui/component/header_list_item.js
@@ -2,11 +2,24 @@
 // See LICENSE.txt for license information.
 
 class HeaderListItem {
-    getItemAtIndex = (index) => {
+    testID = {
+        addHeadersItemPrefix: 'add_headers.header_list_item.',
+        listHeadersItemPrefix: 'list_headers.header_list_item.',
+    }
+
+    getItemAtIndex = (prefix, index) => {
         return {
-            keyInput: element(by.id(`header_list_item.${index}.key.input`)).atIndex(0),
-            valueInput: element(by.id(`header_list_item.${index}.value.input`)).atIndex(0),
+            keyInput: element(by.id(`${prefix}${index}.key.input`)).atIndex(0),
+            valueInput: element(by.id(`${prefix}${index}.value.input`)).atIndex(0),
         }
+    }
+
+    getAddHeadersItemAtIndex = (index) => {
+        return this.getItemAtIndex(this.testID.addHeadersItemPrefix, index);
+    }
+
+    getListHeadersItemAtIndex = (index) => {
+        return this.getItemAtIndex(this.testID.listHeadersItemPrefix, index);
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/api_client.js
+++ b/example/detox/e2e/support/ui/screen/api_client.js
@@ -5,14 +5,17 @@ import {
     HeaderListItem,
     MethodButtons,
 } from '@support/ui/component';
+import {isAndroid} from '@support/utils';
 
 class ApiClientScreen {
     testID = {
+        apiClientScrollView: 'api_client.scroll_view',
         baseUrlInput: 'api_client.base_url.input',
         nameInput: 'api_client.name.input',
     }
 
     apiClientScreen = element(by.text('APIClient'));
+    apiClientScrollView = element(by.id(this.testID.apiClientScrollView));
     baseUrlInput = element(by.id(this.testID.baseUrlInput));
     nameInput = element(by.id(this.testID.nameInput));
     clientListButton = element(by.text('ClientList')).atIndex(0);
@@ -20,14 +23,14 @@ class ApiClientScreen {
     uploadButton = element(by.text('UPLOAD'));
 
     // convenience props
-    getButton = MethodButtons.getButton;
     deleteButton = MethodButtons.deleteButton;
+    getButton = MethodButtons.getButton;
     patchButton = MethodButtons.patchButton;
     postButton = MethodButtons.postButton;
     putButton = MethodButtons.putButton;
 
     getHeaderListItemAtIndex = (index) => {
-        return HeaderListItem.getItemAtIndex(index);
+        return HeaderListItem.getListHeadersItemAtIndex(index);
     }
 
     toBeVisible = async () => {
@@ -44,8 +47,47 @@ class ApiClientScreen {
     }
 
     back = async () => {
-        await this.clientListButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.clientListButton.tap();
+        }
         await expect(this.apiClientScreen).not.toBeVisible();
+    }
+
+    selectDelete = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.deleteButton.tap();
+    }
+
+    selectGet = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.getButton.tap();
+    }
+
+    selectFastImage = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.fastImageButton.tap();
+    }
+
+    selectPatch = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.patchButton.tap();
+    }
+
+    selectPost = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.postButton.tap();
+    }
+
+    selectPut = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.putButton.tap();
+    }
+
+    selectUpload = async () => {
+        await this.apiClientScrollView.scrollTo('bottom');
+        await this.uploadButton.tap();
     }
 }
 

--- a/example/detox/e2e/support/ui/screen/api_client_fast_image.js
+++ b/example/detox/e2e/support/ui/screen/api_client_fast_image.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {isAndroid} from '@support/utils';
+
 class ApiClientFastImageScreen {
     testID = {
         imageUrlInput: 'api_client_fast_image.image_url.input',
@@ -20,7 +22,11 @@ class ApiClientFastImageScreen {
     }
 
     back = async () => {
-        await this.apiClientButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.apiClientButton.tap();
+        }
         await expect(this.apiClientFastImageScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/support/ui/screen/api_client_request.js
+++ b/example/detox/e2e/support/ui/screen/api_client_request.js
@@ -6,6 +6,7 @@ import {
     ResponseOverlay,
     RetryPolicyConfiguration,
 } from '@support/ui/component';
+import {isAndroid} from '@support/utils';
 
 class ApiClientRequestScreen {
     testID = {
@@ -34,7 +35,11 @@ class ApiClientRequestScreen {
     }
 
     back = async () => {
-        await this.apiClientButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.apiClientButton.tap();
+        }
         await expect(this.apiClientRequestScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/support/ui/screen/api_client_upload.js
+++ b/example/detox/e2e/support/ui/screen/api_client_upload.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {ProgressiveFileUpload} from '@support/ui/component';
+import {isAndroid} from '@support/utils';
 
 class ApiClientUploadScreen {
     testID = {
@@ -31,7 +32,11 @@ class ApiClientUploadScreen {
     }
 
     back = async () => {
-        await this.apiClientButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.apiClientButton.tap();
+        }
         await expect(this.apiClientUploadScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/support/ui/screen/client_list.js
+++ b/example/detox/e2e/support/ui/screen/client_list.js
@@ -4,7 +4,12 @@
 import {Alert} from '@support/ui/component';
 
 class ClientListScreen {
+    testID = {
+        clientListScrollView: 'client_list.scroll_view',
+    }
+
     clientListScreen = element(by.text('ClientList'));
+    clientListScrollView = element(by.id(this.testID.clientListScrollView));
     genericClientAction = element(by.text('Generic'));
     addApiClientButton = element(by.text('Add API Client'));
     addWebSocketClientButton = element(by.text('Add WebSocket Client'));

--- a/example/detox/e2e/support/ui/screen/create_api_client.js
+++ b/example/detox/e2e/support/ui/screen/create_api_client.js
@@ -6,6 +6,7 @@ import {
     RetryPolicyConfiguration,
 } from '@support/ui/component';
 import {ClientListScreen} from '@support/ui/screen';
+import {isAndroid} from '@support/utils';
 
 class CreateApiClientScreen {
     testID = {
@@ -58,7 +59,11 @@ class CreateApiClientScreen {
     }
 
     back = async () => {
-        await this.clientListButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.clientListButton.tap();
+        }
         await expect(this.createApiClientScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/support/ui/screen/create_web_socket_client.js
+++ b/example/detox/e2e/support/ui/screen/create_web_socket_client.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {ClientListScreen} from '@support/ui/screen';
+import {isAndroid} from '@support/utils';
 
 class CreateWebSocketClientScreen {
     createWebSocketClientScreen = element(by.text('CreateWebSocketClient'));
@@ -28,7 +29,11 @@ class CreateWebSocketClientScreen {
     }
 
     back = async () => {
-        await this.clientListButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.clientListButton.tap();
+        }
         await expect(this.createWebSocketClientScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/support/ui/screen/generic_client_request.js
+++ b/example/detox/e2e/support/ui/screen/generic_client_request.js
@@ -8,6 +8,7 @@ import {
     RetryPolicyConfiguration,
 } from '@support/ui/component';
 import {ClientListScreen} from '@support/ui/screen';
+import {isAndroid} from '@support/utils';
 
 class GenericClientRequestScreen {
     testID = {
@@ -53,7 +54,11 @@ class GenericClientRequestScreen {
     }
 
     back = async () => {
-        await this.clientListButton.tap();
+        if (isAndroid()) {
+            await device.pressBack();
+        } else {
+            await this.clientListButton.tap();
+        }
         await expect(this.genericClientRequestScreen).not.toBeVisible();
     }
 

--- a/example/detox/e2e/test/client/create_api_client.e2e.js
+++ b/example/detox/e2e/test/client/create_api_client.e2e.js
@@ -37,6 +37,10 @@ describe('Create API Client', () => {
         exponentialBackoffScale: `${getRandomInt(5) + 3}`,
     };
     const {
+        clientListScrollView,
+        removeClientWithName,
+    } = ClientListScreen;
+    const {
         createApiClientScrollView,
         createClient,
         setBaseUrl,
@@ -72,6 +76,7 @@ describe('Create API Client', () => {
         await createClient();
 
         // * Verify created client
+        await clientListScrollView.scrollTo('bottom');
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, testHeaders);
 
@@ -105,7 +110,7 @@ describe('Create API Client', () => {
 
     it('should be able to remove an API client', async () => {
         // # Remove client
-        await ClientListScreen.removeClientWithName(testName);
+        await removeClientWithName(testName);
 
         // * Verify client is removed
         await expect(element(by.text(testName))).not.toBeVisible();

--- a/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
@@ -46,7 +46,7 @@ describe('Delete - API Client Request', () => {
 
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, customHeaders);
-        await ApiClientScreen.deleteButton.tap();
+        await ApiClientScreen.selectDelete();
     });
 
     it('should return a valid response', async () => {

--- a/example/detox/e2e/test/fast_image/fast_image_cookie_token_api_client_request.e2e.js
+++ b/example/detox/e2e/test/fast_image/fast_image_cookie_token_api_client_request.e2e.js
@@ -28,7 +28,7 @@ describe('Fast Image Cookie Token - API Client Request', () => {
     beforeAll(async () => {
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl);
-        await ApiClientScreen.fastImageButton.tap();
+        await ApiClientScreen.selectFastImage();
     });
 
     it('should display fast image - with cookie token on protected request', async () => {

--- a/example/detox/e2e/test/fast_image/fast_image_header_token_api_client_request.e2e.js
+++ b/example/detox/e2e/test/fast_image/fast_image_header_token_api_client_request.e2e.js
@@ -27,7 +27,7 @@ describe('Fast Image Header Token - API Client Request', () => {
     beforeAll(async () => {
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl);
-        await ApiClientScreen.fastImageButton.tap();
+        await ApiClientScreen.selectFastImage();
     });
 
     it('should display fast image - with header token on protected request', async () => {

--- a/example/detox/e2e/test/fast_image/fast_image_regular_api_client_request.e2e.js
+++ b/example/detox/e2e/test/fast_image/fast_image_regular_api_client_request.e2e.js
@@ -27,7 +27,7 @@ describe('Fast Image Regular - API Client Request', () => {
     beforeAll(async () => {
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl);
-        await ApiClientScreen.fastImageButton.tap();
+        await ApiClientScreen.selectFastImage();
     });
 
     it('should display fast image - regular request', async () => {

--- a/example/detox/e2e/test/get/get_api_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_api_client_request.e2e.js
@@ -44,7 +44,7 @@ describe('Get - API Client Request', () => {
 
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, customHeaders);
-        await ApiClientScreen.getButton.tap();
+        await ApiClientScreen.selectGet();
     });
 
     it('should return a valid response', async () => {

--- a/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
@@ -46,7 +46,7 @@ describe('Patch - API Client Request', () => {
 
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, customHeaders);
-        await ApiClientScreen.patchButton.tap();
+        await ApiClientScreen.selectPatch();
     });
 
     it('should return a valid response', async () => {

--- a/example/detox/e2e/test/post/post_api_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_api_client_request.e2e.js
@@ -46,7 +46,7 @@ describe('Post - API Client Request', () => {
 
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, customHeaders);
-        await ApiClientScreen.postButton.tap();
+        await ApiClientScreen.selectPost();
     });
 
     it('should return a valid response', async () => {

--- a/example/detox/e2e/test/put/put_api_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_api_client_request.e2e.js
@@ -46,7 +46,7 @@ describe('Put - API Client Request', () => {
 
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl, customHeaders);
-        await ApiClientScreen.putButton.tap();
+        await ApiClientScreen.selectPut();
     });
 
     it('should return a valid response', async () => {

--- a/example/detox/e2e/test/upload/upload_api_client_request.e2e.js
+++ b/example/detox/e2e/test/upload/upload_api_client_request.e2e.js
@@ -23,7 +23,7 @@ describe('Upload - API Client Request', () => {
     beforeAll(async () => {
         await ApiClientScreen.open(testName);
         await verifyApiClient(testName, testBaseUrl);
-        await ApiClientScreen.uploadButton.tap();
+        await ApiClientScreen.selectUpload();
     });
 
     it('should be able to upload selected file', async () => {

--- a/example/mockserver.js
+++ b/example/mockserver.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+var http       = require('http');
+var mockserver = require('mockserver');
+var argv       = require('yargs').argv;
+var colors     = require('colors')
+var mocks      = argv.m || argv.mocks;
+var port       = argv.p || argv.port;
+
+if (!mocks || !port) {
+    console.log([
+        "Mockserver",
+        "",
+        "Usage:",
+        "  mockserver -p PORT -m PATH",
+        "",
+        "Options:",
+        "  -p, --port=PORT    - Port to listen on",
+        "  -m, --mocks=PATH   - Path to mock files",
+        "",
+        "Example:",
+        "  node mockserver.js -p 8080 -m './mocks'"
+    ].join("\n"));
+} else {
+    http.createServer(mockserver(mocks)).listen(port);
+    console.log('Mockserver serving mocks '
+        + 'under "' + mocks.green  + '" at '
+        + 'http://localhost:'.green + port.toString().green);
+}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2245,6 +2245,12 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3495,6 +3501,12 @@
         }
       }
     },
+    "header-case-normalizer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/header-case-normalizer/-/header-case-normalizer-1.0.3.tgz",
+      "integrity": "sha1-+x1MjQxhadyrT3x+IbGGpqIqwME=",
+      "dev": true
+    },
     "hermes-engine": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.5.1.tgz",
@@ -3670,6 +3682,12 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -4219,6 +4237,12 @@
       "resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.6.tgz",
       "integrity": "sha512-JNAkmPeB/GS2tCRqUzRPsTOHpGDah7xP18vGJfIjZC+W2sxEHbxgJxetIjIqhjQ3yYbYNEELkM/spKLtwoOSUQ=="
     },
+    "js-combinatorics": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.5.tgz",
+      "integrity": "sha512-WglFY9EQvwndNhuJLxxyjnC16649lfZly/G3M3zgQMwcWlJDJ0Jn9niPWeYjnLXwWOEycYVxR2Tk98WLeFkrcw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4344,6 +4368,15 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
       }
     },
     "leven": {
@@ -4576,6 +4609,15 @@
         "tmpl": "1.0.x"
       }
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4611,6 +4653,25 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -5494,6 +5555,179 @@
         "minimist": "^1.2.5"
       }
     },
+    "mockserver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/mockserver/-/mockserver-3.1.1.tgz",
+      "integrity": "sha512-VYozi451X9xcFIVaAlo8NtmYzh9uI76UfZKuAS1/bMZ65GXLKfbzuClS/SsDG2A3BDStI2/5JAUZkhz79weBXA==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.3.2",
+        "header-case-normalizer": "^1.0.3",
+        "js-combinatorics": "^0.5.0",
+        "yargs": "^12.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
@@ -5640,6 +5874,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "ob1": {
       "version": "0.58.0",
@@ -5817,15 +6057,38 @@
         }
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "ios": "react-native run-ios",
     "fast-image-server": "node file_server.js -p 8009 -u './detox/e2e/support/fixtures'",
     "file-upload-server": "node file_server.js -p 8008 -u './upload'",
-    "mockserver": "mockserver -p 8080 -m './mocks'",
+    "mockserver": "node mockserver.js -p 8080 -m './mocks'",
     "postinstall": "patch-package",
     "start": "react-native start"
   },
@@ -49,6 +49,7 @@
     "express-jwt": "6.0.0",
     "jsonwebtoken": "8.5.1",
     "metro-react-native-babel-preset": "0.63.0",
+    "mockserver": "3.1.1",
     "patch-package": "^6.2.2"
   }
 }

--- a/example/src/components/AddHeaders.tsx
+++ b/example/src/components/AddHeaders.tsx
@@ -59,6 +59,7 @@ const AddHeaders = ({ onHeadersChanged }: AddHeadersProps) => {
                         header={header}
                         index={index}
                         updateHeader={updateHeader}
+                        testID="add_headers.header_list_item"
                     />
                 ))}
             </View>

--- a/example/src/components/HeaderListItem.tsx
+++ b/example/src/components/HeaderListItem.tsx
@@ -9,6 +9,7 @@ type HeaderListItemProps = {
     header: Header;
     updateHeader?: (header: Header, index: number) => void;
     disabled?: boolean;
+    testID?: string;
 };
 
 const HeaderListItem = ({
@@ -16,6 +17,7 @@ const HeaderListItem = ({
     header,
     updateHeader,
     disabled,
+    testID,
 }: HeaderListItemProps) => {
     const updateHeaderKey = (key: string) =>
         updateHeader && updateHeader({ ...header, key }, index);
@@ -30,7 +32,7 @@ const HeaderListItem = ({
                 placeholder="key"
                 value={header.key}
                 disabled={disabled}
-                testID={`header_list_item.${index}.key.input`}
+                testID={`${testID}.${index}.key.input`}
             />
             <Input
                 containerStyle={{ flex: 1 }}
@@ -38,7 +40,7 @@ const HeaderListItem = ({
                 placeholder="value"
                 value={header.value}
                 disabled={disabled}
-                testID={`header_list_item.${index}.value.input`}
+                testID={`${testID}.${index}.value.input`}
             />
         </ListItem>
     );

--- a/example/src/components/ListHeaders.tsx
+++ b/example/src/components/ListHeaders.tsx
@@ -37,6 +37,7 @@ const ListHeaders = ({ headers }: ListHeadersProps) => (
                     header={header}
                     index={index}
                     disabled={true}
+                    testID="list_headers.header_list_item"
                 />
             ))}
         </View>

--- a/example/src/screens/APIClientScreen.tsx
+++ b/example/src/screens/APIClientScreen.tsx
@@ -95,7 +95,7 @@ export default function APIClientScreen({
 
     return (
         <SafeAreaView>
-            <ScrollView>
+            <ScrollView testID="api_client.scroll_view">
                 <Input
                     label="Name"
                     value={name}

--- a/example/src/screens/ClientListScreen.tsx
+++ b/example/src/screens/ClientListScreen.tsx
@@ -66,6 +66,7 @@ export default function ClientListScreen({
                 data={clients}
                 renderItem={renderItem}
                 keyExtractor={networkClientKeyExtractor}
+                testID="client_list.scroll_view"
             />
             <ButtonGroup
                 buttons={buttons.map((button) => button.title)}


### PR DESCRIPTION
#### Summary
- Fixed e2e tests, components, screens to adapt to android example app
- Added new testIDs
- Pulled mockserver to local file so that we have more control on how it is used (npm sometimes installs the wrong mockserver using `npm install mockserver`)

Note: All e2e tests passed for iOS. For android, most passed except for `upload_api_client_request` e2e test, which is expected because https://github.com/mattermost/react-native-network-client/pull/32 hasn't been tested and merged yet (see results below)

#### Ticket Link
JIRA:
- https://mattermost.atlassian.net/browse/MM-32807
- https://mattermost.atlassian.net/browse/MM-32243

|iOS Results|Android Results|
|:---|:---|
|![Screen Shot 2021-03-11 at 11 15 00 AM](https://user-images.githubusercontent.com/487991/110842519-0a84a780-825c-11eb-9de0-d7f1fc22f22b.png)|![Screen Shot 2021-03-11 at 11 23 44 AM](https://user-images.githubusercontent.com/487991/110842695-4cade900-825c-11eb-9f81-df375aae1c7d.png)|