### PR TITLE
MM-34139 Detox/E2E: Sample iOS E2E for client errors

### DIFF
--- a/example/detox/e2e/support/ui/component/response_error_overlay.js
+++ b/example/detox/e2e/support/ui/component/response_error_overlay.js
@@ -28,6 +28,10 @@ class ResponseErrorOverlay {
     responseErrorUserInfoText = element(
         by.id(this.testID.responseErrorUserInfoText)
     );
+
+    close = async () => {
+        await this.responseErrorCloseButton.tap();
+    };
 }
 
 const responseErrorOverlay = new ResponseErrorOverlay();

--- a/example/detox/e2e/support/ui/component/response_success_overlay.js
+++ b/example/detox/e2e/support/ui/component/response_success_overlay.js
@@ -33,6 +33,10 @@ class ResponseSuccessOverlay {
     responseSuccessRetriesExhaustedText = element(
         by.id(this.testID.responseSuccessRetriesExhaustedText)
     );
+
+    close = async () => {
+        await this.responseSuccessCloseButton.tap();
+    };
 }
 
 const responseSuccessOverlay = new ResponseSuccessOverlay();

--- a/example/detox/e2e/support/ui/component/retry_policy_configuration.js
+++ b/example/detox/e2e/support/ui/component/retry_policy_configuration.js
@@ -40,10 +40,10 @@ class RetryPolicyConfiguration {
 
     setRetry = async ({
         retryPolicyType = "exponential",
-        retryLimit = "2",
-        exponentialBackoffBase = "2",
-        exponentialBackoffScale = "0.5",
-        retryInterval = "2000",
+        retryLimit = 2,
+        exponentialBackoffBase = 2,
+        exponentialBackoffScale = 0.5,
+        retryInterval = 2000,
     }) => {
         switch (retryPolicyType) {
             case "exponential":
@@ -64,9 +64,9 @@ class RetryPolicyConfiguration {
     };
 
     setExponentialRetry = async ({
-        retryLimit = "2",
-        exponentialBackoffBase = "2",
-        exponentialBackoffScale = "0.5",
+        retryLimit = 2,
+        exponentialBackoffBase = 2,
+        exponentialBackoffScale = 0.5,
     }) => {
         // # Toggle on exponential retry checkbox
         await this.toggleOnExponentialRetryCheckbox();
@@ -81,7 +81,7 @@ class RetryPolicyConfiguration {
         await this.setExponentialBackoffScale(exponentialBackoffScale);
     };
 
-    setLinearRetry = async ({ retryLimit = "2", retryInterval = "2000" }) => {
+    setLinearRetry = async ({ retryLimit = 2, retryInterval = 2000 }) => {
         if (isAndroid()) {
             await waitForAndScrollDown(
                 this.linearRetryCheckboxTrue,
@@ -101,82 +101,90 @@ class RetryPolicyConfiguration {
     };
 
     setExponentialBackoffBase = async (exponentialBackoffBase) => {
+        const exponentialBackoffBaseStr = exponentialBackoffBase.toString();
         const exponentialBackoffBaseInput = this.getExponentialBackoffBaseInput();
         await waitForAndScrollDown(
             exponentialBackoffBaseInput,
             this.testID.screenScrollView
         );
         await exponentialBackoffBaseInput.clearText();
-        await exponentialBackoffBaseInput.replaceText(exponentialBackoffBase);
+        await exponentialBackoffBaseInput.replaceText(
+            exponentialBackoffBaseStr
+        );
         await exponentialBackoffBaseInput.tapReturnKey();
 
         // * Verify input value
         if (isAndroid()) {
             await expect(exponentialBackoffBaseInput).toHaveText(
-                exponentialBackoffBase
+                exponentialBackoffBaseStr
             );
         } else {
             await expect(exponentialBackoffBaseInput).toHaveValue(
-                exponentialBackoffBase
+                exponentialBackoffBaseStr
             );
         }
     };
 
     setExponentialBackoffScale = async (exponentialBackoffScale) => {
+        const exponentialBackoffScaleStr = exponentialBackoffScale.toString();
         const exponentialBackoffScaleInput = this.getExponentialBackoffScaleInput();
         await waitForAndScrollDown(
             exponentialBackoffScaleInput,
             this.testID.screenScrollView
         );
         await exponentialBackoffScaleInput.clearText();
-        await exponentialBackoffScaleInput.replaceText(exponentialBackoffScale);
+        await exponentialBackoffScaleInput.replaceText(
+            exponentialBackoffScaleStr
+        );
         await exponentialBackoffScaleInput.tapReturnKey();
 
         // * Verify input value
         if (isAndroid()) {
             await expect(exponentialBackoffScaleInput).toHaveText(
-                exponentialBackoffScale
+                exponentialBackoffScaleStr
             );
         } else {
             await expect(exponentialBackoffScaleInput).toHaveValue(
-                exponentialBackoffScale
+                exponentialBackoffScaleStr
             );
         }
     };
 
     setRetryInterval = async (retryInterval) => {
+        const retryIntervalStr = retryInterval.toString();
         const retryIntervalInput = this.getRetryIntervalInput();
         await waitForAndScrollDown(
             retryIntervalInput,
             this.testID.screenScrollView
         );
         await retryIntervalInput.clearText();
-        await retryIntervalInput.replaceText(retryInterval);
+        await retryIntervalInput.replaceText(retryIntervalStr);
         await retryIntervalInput.tapReturnKey();
 
         // * Verify input value
         if (isAndroid()) {
-            await expect(retryIntervalInput).toHaveText(retryInterval);
+            await expect(retryIntervalInput).toHaveText(retryIntervalStr);
         } else {
-            await expect(retryIntervalInput).toHaveValue(retryInterval);
+            await expect(retryIntervalInput).toHaveValue(retryIntervalStr);
         }
     };
 
     setRetryLimit = async (retryLimit) => {
+        const retryLimitStr = retryLimit.toString();
         const retryLimitInput = this.getRetryLimitInput();
         await waitForAndScrollDown(
             retryLimitInput,
             this.testID.screenScrollView
         );
         await retryLimitInput.clearText();
-        await retryLimitInput.replaceText(retryLimit);
+        await retryLimitInput.replaceText(retryLimitStr);
         await retryLimitInput.tapReturnKey();
 
         // * Verify input value
         if (isAndroid()) {
-            await expect(retryLimitInput).toHaveText(retryLimit);
+            await expect(retryLimitInput).toHaveText(retryLimitStr);
         } else {
-            await expect(retryLimitInput).toHaveValue(retryLimit);
+            await expect(retryLimitInput).toHaveValue(retryLimitStr);
         }
     };
 

--- a/example/detox/e2e/support/ui/screen/api_client_request.js
+++ b/example/detox/e2e/support/ui/screen/api_client_request.js
@@ -1,11 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {
-    AddHeaders,
-    ResponseSuccessOverlay,
-    RetryPolicyConfiguration,
-} from "@support/ui/component";
+import { AddHeaders, RetryPolicyConfiguration } from "@support/ui/component";
 import { isAndroid, waitForAndScrollDown } from "@support/utils";
 
 class ApiClientRequestScreen {
@@ -25,20 +21,6 @@ class ApiClientRequestScreen {
     pathInput = element(by.id(this.testID.pathInput));
     timeoutIntervalInput = element(by.id(this.testID.timeoutIntervalInput));
     requestButton = element(by.text("Request"));
-
-    // convenience props
-    responseSuccessOverlay = ResponseSuccessOverlay.responseSuccessOverlay;
-    responseSuccessCloseButton =
-        ResponseSuccessOverlay.responseSuccessCloseButton;
-    responseSuccessCodeText = ResponseSuccessOverlay.responseSuccessCodeText;
-    responseSuccessDataText = ResponseSuccessOverlay.responseSuccessDataText;
-    responseSuccessHeadersText =
-        ResponseSuccessOverlay.responseSuccessHeadersText;
-    responseSuccessLastRequestedUrlText =
-        ResponseSuccessOverlay.responseSuccessLastRequestedUrlText;
-    responseSuccessOkText = ResponseSuccessOverlay.responseSuccessOkText;
-    responseSuccessRetriesExhaustedText =
-        ResponseSuccessOverlay.responseSuccessRetriesExhaustedText;
 
     retryPolicyConfiguration = new RetryPolicyConfiguration(
         this.testID.apiClientRequestScrollView
@@ -94,22 +76,23 @@ class ApiClientRequestScreen {
     setRetry = async (
         options = {
             retryPolicyType: "exponential",
-            retryLimit: "2",
-            exponentialBackoffBase: "2",
-            exponentialBackoffScale: "0.5",
-            retryInterval: "2000",
+            retryLimit: 2,
+            exponentialBackoffBase: 2,
+            exponentialBackoffScale: 0.5,
+            retryInterval: 2000,
         }
     ) => {
         await this.retryPolicyConfiguration.setRetry(options);
     };
 
     setTimeoutInterval = async (timeoutInterval) => {
+        const timeoutIntervalStr = timeoutInterval.toString();
         await waitForAndScrollDown(
             this.timeoutIntervalInput,
             this.testID.apiClientRequestScrollView
         );
         await this.timeoutIntervalInput.clearText();
-        await this.timeoutIntervalInput.replaceText(timeoutInterval);
+        await this.timeoutIntervalInput.replaceText(timeoutIntervalStr);
         await this.timeoutIntervalInput.tapReturnKey();
     };
 }

--- a/example/detox/e2e/support/ui/screen/create_api_client.js
+++ b/example/detox/e2e/support/ui/screen/create_api_client.js
@@ -143,12 +143,13 @@ class CreateApiClientScreen {
     };
 
     setMaxConnections = async (maxConnections) => {
+        const maxConnectionsStr = maxConnections.toString();
         await waitForAndScrollDown(
             this.maxConnectionsInput,
             this.testID.createApiClientScrollView
         );
         await this.maxConnectionsInput.clearText();
-        await this.maxConnectionsInput.replaceText(maxConnections);
+        await this.maxConnectionsInput.replaceText(maxConnectionsStr);
         await this.maxConnectionsInput.tapReturnKey();
     };
 
@@ -163,25 +164,27 @@ class CreateApiClientScreen {
     };
 
     setRequestTimeoutInterval = async (requestTimeoutInterval) => {
+        const requestTimeoutIntervalStr = requestTimeoutInterval.toString();
         await waitForAndScrollDown(
             this.requestTimeoutIntervalInput,
             this.testID.createApiClientScrollView
         );
         await this.requestTimeoutIntervalInput.clearText();
         await this.requestTimeoutIntervalInput.replaceText(
-            requestTimeoutInterval
+            requestTimeoutIntervalStr
         );
         await this.requestTimeoutIntervalInput.tapReturnKey();
     };
 
     setResourceTimeoutInterval = async (resourceTimeoutInterval) => {
+        const resourceTimeoutIntervalStr = resourceTimeoutInterval.toString();
         await waitForAndScrollDown(
             this.resourceTimeoutIntervalInput,
             this.testID.createApiClientScrollView
         );
         await this.resourceTimeoutIntervalInput.clearText();
         await this.resourceTimeoutIntervalInput.replaceText(
-            resourceTimeoutInterval
+            resourceTimeoutIntervalStr
         );
         await this.resourceTimeoutIntervalInput.tapReturnKey();
     };
@@ -189,10 +192,10 @@ class CreateApiClientScreen {
     setRetry = async (
         options = {
             retryPolicyType: "exponential",
-            retryLimit: "2",
-            exponentialBackoffBase: "2",
-            exponentialBackoffScale: "0.5",
-            retryInterval: "2000",
+            retryLimit: 2,
+            exponentialBackoffBase: 2,
+            exponentialBackoffScale: 0.5,
+            retryInterval: 2000,
         }
     ) => {
         await this.retryPolicyConfiguration.setRetry(options);

--- a/example/detox/e2e/support/ui/screen/create_websocket_client.js
+++ b/example/detox/e2e/support/ui/screen/create_websocket_client.js
@@ -97,12 +97,13 @@ class CreateWebSocketClientScreen {
     };
 
     setTimeoutInterval = async (timeoutInterval) => {
+        const timeoutIntervalStr = timeoutInterval.toString();
         await waitForAndScrollDown(
             this.timeoutIntervalInput,
             this.testID.createWebSocketClientScrollView
         );
         await this.timeoutIntervalInput.clearText();
-        await this.timeoutIntervalInput.replaceText(timeoutInterval);
+        await this.timeoutIntervalInput.replaceText(timeoutIntervalStr);
         await this.timeoutIntervalInput.tapReturnKey();
     };
 

--- a/example/detox/e2e/support/ui/screen/generic_client_request.js
+++ b/example/detox/e2e/support/ui/screen/generic_client_request.js
@@ -4,7 +4,6 @@
 import {
     AddHeaders,
     MethodButtons,
-    ResponseSuccessOverlay,
     RetryPolicyConfiguration,
 } from "@support/ui/component";
 import { ClientListScreen } from "@support/ui/screen";
@@ -34,18 +33,6 @@ class GenericClientRequestScreen {
     patchButton = MethodButtons.patchButton;
     postButton = MethodButtons.postButton;
     putButton = MethodButtons.putButton;
-    responseSuccessOverlay = ResponseSuccessOverlay.responseSuccessOverlay;
-    responseSuccessCloseButton =
-        ResponseSuccessOverlay.responseSuccessCloseButton;
-    responseSuccessCodeText = ResponseSuccessOverlay.responseSuccessCodeText;
-    responseSuccessDataText = ResponseSuccessOverlay.responseSuccessDataText;
-    responseSuccessHeadersText =
-        ResponseSuccessOverlay.responseSuccessHeadersText;
-    responseSuccessLastRequestedUrlText =
-        ResponseSuccessOverlay.responseSuccessLastRequestedUrlText;
-    responseSuccessOkText = ResponseSuccessOverlay.responseSuccessOkText;
-    responseSuccessRetriesExhaustedText =
-        ResponseSuccessOverlay.responseSuccessRetriesExhaustedText;
 
     retryPolicyConfiguration = new RetryPolicyConfiguration(
         this.testID.genericClientRequestScrollView
@@ -98,22 +85,23 @@ class GenericClientRequestScreen {
     setRetry = async (
         options = {
             retryPolicyType: "exponential",
-            retryLimit: "2",
-            exponentialBackoffBase: "2",
-            exponentialBackoffScale: "0.5",
-            retryInterval: "2000",
+            retryLimit: 2,
+            exponentialBackoffBase: 2,
+            exponentialBackoffScale: 0.5,
+            retryInterval: 2000,
         }
     ) => {
         await this.retryPolicyConfiguration.setRetry(options);
     };
 
     setTimeoutInterval = async (timeoutInterval) => {
+        const timeoutIntervalStr = timeoutInterval.toString();
         await waitForAndScrollDown(
             this.timeoutIntervalInput,
             this.testID.genericClientRequestScrollView
         );
         await this.timeoutIntervalInput.clearText();
-        await this.timeoutIntervalInput.replaceText(timeoutInterval);
+        await this.timeoutIntervalInput.replaceText(timeoutIntervalStr);
         await this.timeoutIntervalInput.tapReturnKey();
     };
 

--- a/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
@@ -82,7 +82,11 @@ describe("Delete - API Client Request", () => {
         await ApiClientScreen.selectDelete();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -124,7 +128,11 @@ describe("Delete - API Client Request", () => {
         await ApiClientScreen.selectDelete();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -155,10 +163,10 @@ describe("Delete - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response
@@ -215,10 +223,10 @@ describe("Delete - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response

--- a/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_api_client_request.e2e.js
@@ -183,7 +183,6 @@ describe("Delete - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay
@@ -245,7 +244,6 @@ describe("Delete - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
@@ -28,7 +28,12 @@ describe("Delete - Generic Client Request", () => {
     const testHeaders = { ...customHeaders };
     const testBody = { ...customBody };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return a valid response", async () => {
+        // * Verify direct server response
         const apiResponse = await Request.apiDelete({
             headers: testHeaders,
             body: testBody,
@@ -43,11 +48,10 @@ describe("Delete - Generic Client Request", () => {
             testBody
         );
 
+        // # Select delete
         await GenericClientRequestScreen.open();
         await GenericClientRequestScreen.deleteButton.tap();
-    });
 
-    it("should return a valid response", async () => {
         // # Perform generic client request
         await performGenericClientRequest({
             testUrl: testServerUrl,

--- a/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/delete/delete_generic_client_request.e2e.js
@@ -54,9 +54,9 @@ describe("Delete - Generic Client Request", () => {
 
         // # Perform generic client request
         await performGenericClientRequest({
-            testUrl: testServerUrl,
-            testHeaders,
-            testBody,
+            body: testBody,
+            headers: testHeaders,
+            url: testServerUrl,
         });
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/get/get_api_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_api_client_request.e2e.js
@@ -176,7 +176,6 @@ describe("Get - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay
@@ -236,7 +235,6 @@ describe("Get - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/get/get_api_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_api_client_request.e2e.js
@@ -78,7 +78,7 @@ describe("Get - API Client Request", () => {
         await ApiClientScreen.selectGet();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders });
+        await performApiClientRequest({ headers: testHeaders, path: testPath });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -118,7 +118,7 @@ describe("Get - API Client Request", () => {
         await ApiClientScreen.selectGet();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders });
+        await performApiClientRequest({ headers: testHeaders, path: testPath });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -149,9 +149,9 @@ describe("Get - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testRetry,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response
@@ -207,9 +207,9 @@ describe("Get - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testRetry,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response

--- a/example/detox/e2e/test/get/get_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_generic_client_request.e2e.js
@@ -26,7 +26,12 @@ describe("Get - Generic Client Request", () => {
     const testStatus = 200;
     const testHeaders = { ...customHeaders };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return a valid response", async () => {
+        // * Verify direct server response
         const apiResponse = await Request.apiGet({ headers: testHeaders });
         await verifyApiResponse(
             apiResponse,
@@ -37,11 +42,10 @@ describe("Get - Generic Client Request", () => {
             testHeaders
         );
 
+        // # Select get
         await GenericClientRequestScreen.open();
         await GenericClientRequestScreen.getButton.tap();
-    });
 
-    it("should return a valid response", async () => {
         // # Perform generic client request
         await performGenericClientRequest({
             testUrl: testServerUrl,

--- a/example/detox/e2e/test/get/get_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/get/get_generic_client_request.e2e.js
@@ -48,8 +48,8 @@ describe("Get - Generic Client Request", () => {
 
         // # Perform generic client request
         await performGenericClientRequest({
-            testUrl: testServerUrl,
-            testHeaders,
+            headers: testHeaders,
+            url: testServerUrl,
         });
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/helpers.js
+++ b/example/detox/e2e/test/helpers.js
@@ -33,35 +33,35 @@ export const customBody = {
 export const retryPolicyTypes = ["exponential", "linear"];
 
 /**
- * Create API client.
- * @param {string} testName - client name
- * @param {string} testBaseUrl - base URL of requested server
- * @param {Object} testHeaders - request headers
- * @param {string} testToken - request authentication token
- * @param {number} testRequestTimeoutInterval - client request timeout interval
- * @param {number} testResourceTimeoutInterval - client resource timeout interval
- * @param {number} testMaxConnections - client max connections
- * @param {Object} testRetry - client retry configuration
+ * Create API client. 
+ * @param {string} options.baseUrl - base URL of requested server
  * @param {string} options.clientCertPassword - secure client certificate password
+ * @param {Object} options.headers - request headers
+ * @param {string} options.name - client name
+ * @param {number} options.maxConnections - client max connections
+ * @param {number} options.requestTimeoutInterval - client request timeout interval
+ * @param {number} options.resourceTimeoutInterval - client resource timeout interval
+ * @param {Object} options.retry - client retry configuration
  * @param {boolean} options.secure - if server is secure, true; otherwise, false
  * @param {string} options.secureServerClientCertUrl - secure server client certificate URL
  * @param {boolean} options.toggleOn - if true, checkboxes are toggled on
+ * @param {string} options.token - request authentication token
  * @param {boolean} options.verify - if true, client created is verified
  */
 export const createApiClient = async (
-    testName,
-    testBaseUrl,
-    testHeaders = null,
-    testToken = null,
-    testRequestTimeoutInterval = null,
-    testResourceTimeoutInterval = null,
-    testMaxConnections = null,
-    testRetry = null,
     {
+        baseUrl = null,
         clientCertPassword = null,
+        headers = null,
+        name = null,
+        maxConnections = null,
+        requestTimeoutInterval = null,
+        resourceTimeoutInterval = null,
+        retry = null,
         secure = false,
         secureServerClientCertUrl = null,
         toggleOn = false,
+        token = null,
         verify = true,
     } = {}
 ) => {
@@ -84,13 +84,17 @@ export const createApiClient = async (
     await CreateApiClientScreen.open();
 
     // # Set all fields
-    await setName(testName);
-    await setBaseUrl(testBaseUrl);
-    if (testHeaders) {
-        await setHeaders(testHeaders);
+    if (name) {
+        await setName(name);
     }
-    if (testToken) {
-        await setBearerAuthToken(testToken);
+    if (baseUrl) {
+        await setBaseUrl(baseUrl);
+    }
+    if (headers) {
+        await setHeaders(headers);
+    }
+    if (token) {
+        await setBearerAuthToken(token);
     }
     if (secure) {
         await CreateApiClientScreen.downloadP12(
@@ -98,14 +102,14 @@ export const createApiClient = async (
             clientCertPassword
         );
     }
-    if (testRequestTimeoutInterval) {
-        await setRequestTimeoutInterval(testRequestTimeoutInterval);
+    if (requestTimeoutInterval) {
+        await setRequestTimeoutInterval(requestTimeoutInterval);
     }
-    if (testResourceTimeoutInterval) {
-        await setResourceTimeoutInterval(testResourceTimeoutInterval);
+    if (resourceTimeoutInterval) {
+        await setResourceTimeoutInterval(resourceTimeoutInterval);
     }
-    if (testMaxConnections) {
-        await setMaxConnections(testMaxConnections);
+    if (maxConnections) {
+        await setMaxConnections(maxConnections);
     }
     if (toggleOn) {
         await toggleOnWaitsForConnectivityCheckbox();
@@ -114,8 +118,8 @@ export const createApiClient = async (
     if (secure) {
         await toggleOnTrustSelfSignedServerCertificateCheckbox();
     }
-    if (testRetry) {
-        await setRetry(testRetry);
+    if (retry) {
+        await setRetry(retry);
     }
 
     // # Create client
@@ -123,8 +127,8 @@ export const createApiClient = async (
 
     // * Verify created client
     if (verify) {
-        await ApiClientScreen.open(testName);
-        await verifyApiClient(testName, testBaseUrl, testHeaders);
+        await ApiClientScreen.open(name);
+        await verifyApiClient(name, baseUrl, headers);
 
         // # Open client list screen
         await ApiClientScreen.back();
@@ -133,26 +137,26 @@ export const createApiClient = async (
 
 /**
  * Create WebSocket client.
- * @param {string} testName - client name
- * @param {string} testUrl - URL of requested server
- * @param {Object} testHeaders - request headers
- * @param {number} testTimeoutInterval - client request timeout interval
  * @param {string} options.clientCertPassword - secure client certificate password
+ * @param {Object} options.headers - request headers
+ * @param {string} options.name - client name
  * @param {boolean} options.secure - if server is secure, true; otherwise, false
  * @param {string} options.secureServerClientCertUrl - secure server client certificate URL
+ * @param {number} options.timeoutInterval - client request timeout interval
  * @param {boolean} options.toggleOn - if true, checkboxes are toggled on
+ * @param {string} options.url - URL of requested server
  * @param {boolean} options.verify - if true, client created is verified
  */
 export const createWebSocketClient = async (
-    testName,
-    testUrl,
-    testHeaders = null,
-    testTimeoutInterval = null,
     {
         clientCertPassword = null,
+        headers = null,
+        name = null,
         secure = false,
         secureWebSocketServerClientCertUrl = null,
+        timeoutInterval = null,
         toggleOn = false,
+        url = null,
         verify = true,
     } = {}
 ) => {
@@ -170,10 +174,14 @@ export const createWebSocketClient = async (
     await CreateWebSocketClientScreen.open();
 
     // # Set all fields
-    await setName(testName);
-    await setUrl(testUrl);
-    if (testHeaders) {
-        await setHeaders(testHeaders);
+    if (name) {
+        await setName(name);
+    }
+    if (url) {
+        await setUrl(url);
+    }
+    if (headers) {
+        await setHeaders(headers);
     }
     if (secure) {
         await CreateWebSocketClientScreen.downloadP12(
@@ -181,8 +189,8 @@ export const createWebSocketClient = async (
             clientCertPassword
         );
     }
-    if (testTimeoutInterval) {
-        await setTimeoutInterval(testTimeoutInterval);
+    if (timeoutInterval) {
+        await setTimeoutInterval(timeoutInterval);
     }
     if (toggleOn) {
         await toggleOnEnableCompressionCheckbox();
@@ -197,34 +205,34 @@ export const createWebSocketClient = async (
     // * Verify created client
     if (verify) {
         const { subtitle, title } = await ClientListScreen.getClientByName(
-            testName
+            name
         );
-        await expect(title).toHaveText(testName);
-        await expect(subtitle).toHaveText(testUrl);
+        await expect(title).toHaveText(name);
+        await expect(subtitle).toHaveText(url);
     }
 };
 
 /**
  * Perform API client request.
- * @param {string} options.testPath - relative or absolute path
- * @param {Object} options.testHeaders - requeset headers
- * @param {Object} options.testBody - request body
- * @param {number} options.testTimeoutInterval - client timeout interval
- * @param {Object} options.testRetry - client retry
+ * @param {Object} options.body - request body
+ * @param {Object} options.headers - requeset headers
+ * @param {string} options.path - relative or absolute path
+ * @param {Object} options.retry - client retry
+ * @param {number} options.timeoutInterval - client timeout interval
  * @returns {number} beginTime - timestamp in millis before request is made
  */
 export const performApiClientRequest = async ({
-    testPath,
-    testHeaders = null,
-    testBody = null,
-    testTimeoutInterval = 60,
-    testRetry = {
+    body = null,
+    headers = null,
+    path = null,
+    retry = {
         retryPolicyType: getRandomItem(retryPolicyTypes),
         retryLimit: 3,
         exponentialBackoffBase: 4,
         exponentialBackoffScale: 5,
         retryInterval: 6,
     },
+    timeoutInterval = 60,
 }) => {
     const {
         makeRequest,
@@ -236,18 +244,20 @@ export const performApiClientRequest = async ({
     } = ApiClientRequestScreen;
 
     // # Set all fields
-    await setPath(testPath);
-    if (testHeaders) {
-        await setHeaders(testHeaders);
+    if (path) {
+        await setPath(path);
     }
-    if (testBody) {
-        await setBody(JSON.stringify(testBody));
+    if (headers) {
+        await setHeaders(headers);
     }
-    if (testTimeoutInterval) {
-        await setTimeoutInterval(testTimeoutInterval);
+    if (body) {
+        await setBody(JSON.stringify(body));
     }
-    if (testRetry) {
-        await setRetry(testRetry);
+    if (timeoutInterval) {
+        await setTimeoutInterval(timeoutInterval);
+    }
+    if (retry) {
+        await setRetry(retry);
     }
 
     // # Make request
@@ -258,25 +268,25 @@ export const performApiClientRequest = async ({
 
 /**
  * Perform generic client request.
- * @param {string} options.testUrl - URL of requested server
- * @param {Object} options.testHeaders - requeset headers
- * @param {Object} options.testBody - request body
- * @param {number} options.testTimeoutInterval - client timeout interval
- * @param {Object} options.testRetry - client retry
+ * @param {Object} options.body - request body
+ * @param {Object} options.headers - requeset headers
+ * @param {Object} options.retry - client retry
+ * @param {number} options.timeoutInterval - client timeout interval
+ * @param {string} options.url - URL of requested server
  * @returns {number} beginTime - timestamp in millis before request is made
  */
 export const performGenericClientRequest = async ({
-    testUrl,
-    testHeaders = null,
-    testBody = null,
-    testTimeoutInterval = 60,
-    testRetry = {
+    body = null,
+    headers = null,
+    retry = {
         retryPolicyType: getRandomItem(retryPolicyTypes),
         retryLimit: 3,
         exponentialBackoffBase: 4,
         exponentialBackoffScale: 5,
         retryInterval: 6,
     },
+    timeoutInterval = 60,
+    url = null,
 }) => {
     const {
         makeRequest,
@@ -288,18 +298,20 @@ export const performGenericClientRequest = async ({
     } = GenericClientRequestScreen;
 
     // # Set all fields
-    await setUrl(testUrl);
-    if (testHeaders) {
-        await setHeaders(testHeaders);
+    if (url) {
+        await setUrl(url);
     }
-    if (testBody) {
-        await setBody(JSON.stringify(testBody));
+    if (headers) {
+        await setHeaders(headers);
     }
-    if (testTimeoutInterval) {
-        await setTimeoutInterval(testTimeoutInterval);
+    if (body) {
+        await setBody(JSON.stringify(body));
     }
-    if (testRetry) {
-        await setRetry(testRetry);
+    if (timeoutInterval) {
+        await setTimeoutInterval(timeoutInterval);
+    }
+    if (retry) {
+        await setRetry(retry);
     }
 
     // # Make request
@@ -311,46 +323,46 @@ export const performGenericClientRequest = async ({
 /**
  * Verify API response.
  * @param {Object} apiResponse - response object
- * @param {string} testUrl - URL of requested server
- * @param {number} testStatus - expected response status code
- * @param {string} testHost - host header value of requested server
- * @param {string} testMethod - request method
- * @param {Object} testHeaders - request headers
- * @param {Object} testBody - request body
+ * @param {string} url - URL of requested server
+ * @param {number} status - expected response status code
+ * @param {string} host - host header value of requested server
+ * @param {string} method - request method
+ * @param {Object} headers - request headers
+ * @param {Object} body - request body
  */
 export const verifyApiResponse = async (
     apiResponse,
-    testUrl,
-    testStatus,
-    testHost,
-    testMethod,
-    testHeaders,
-    testBody = null
+    url,
+    status,
+    host,
+    method,
+    headers,
+    body = null
 ) => {
     const apiResponseDataRequest = await apiResponse.data.request;
 
     // * Verify request URL and response status
-    jestExpect(testUrl).toContain(apiResponseDataRequest.url);
-    jestExpect(apiResponse.status).toEqual(testStatus);
+    jestExpect(url).toContain(apiResponseDataRequest.url);
+    jestExpect(apiResponse.status).toEqual(status);
 
     // * Verify response headers contain server header
     jestExpect(apiResponse.headers["server"]).toBe("mockserver");
 
     // * Verify response body contains request host and request method
-    jestExpect(apiResponseDataRequest.headers["host"]).toBe(testHost);
-    jestExpect(apiResponseDataRequest.method).toBe(testMethod);
+    jestExpect(apiResponseDataRequest.headers["host"]).toBe(host);
+    jestExpect(apiResponseDataRequest.method).toBe(method);
 
     // * Verify response body contains request headers
-    for (const [k, v] of Object.entries(testHeaders)) {
+    for (const [k, v] of Object.entries(headers)) {
         jestExpect(apiResponseDataRequest.headers[k]).toBe(v);
     }
 
-    if (testBody) {
+    if (body) {
         // * Verify response body contains request body
         jestExpect(Object.keys(apiResponseDataRequest.body)).toHaveLength(
-            Object.keys(testBody).length
+            Object.keys(body).length
         );
-        for (const [k, v] of Object.entries(testBody)) {
+        for (const [k, v] of Object.entries(body)) {
             jestExpect(apiResponseDataRequest.body[k]).toBe(v);
         }
     }
@@ -358,24 +370,24 @@ export const verifyApiResponse = async (
 
 /**
  * Verify response success overlay.
- * @param {string} testUrl - URL of requested server
- * @param {number} testStatus - expected response status code
- * @param {string} testHost - host header value of requested server
- * @param {string} testMethod - request method
- * @param {Object} testHeaders - request headers
- * @param {Object} testBody - request body
+ * @param {string} url - URL of requested server
+ * @param {number} status - expected response status code
+ * @param {string} host - host header value of requested server
+ * @param {string} method - request method
+ * @param {Object} headers - request headers
+ * @param {Object} body - request body
  * @param {string} options.retriesExhausted - "null", "true", or "false"
  * @param {boolean} options.secure - if server is secure, true; otherwise, false
  * @param {string} options.server - server name
  * @returns {number} endTime - timestamp in millis after response is received
  */
 export const verifyResponseSuccessOverlay = async (
-    testUrl,
-    testStatus,
-    testHost,
-    testMethod,
-    testHeaders,
-    testBody = null,
+    url,
+    status,
+    host,
+    method,
+    headers,
+    body = null,
     { retriesExhausted = "null", secure = false, server = "mockserver" } = {}
 ) => {
     const {
@@ -392,10 +404,10 @@ export const verifyResponseSuccessOverlay = async (
         .toBeVisible()
         .withTimeout(timeouts.TEN_SEC);
     const endTime = Date.now();
-    await expect(responseSuccessLastRequestedUrlText).toHaveText(testUrl);
-    await expect(responseSuccessCodeText).toHaveText(testStatus.toString());
+    await expect(responseSuccessLastRequestedUrlText).toHaveText(url);
+    await expect(responseSuccessCodeText).toHaveText(status.toString());
     await expect(responseSuccessOkText).toHaveText(
-        testStatus === 200 ? "true" : "false"
+        status === 200 ? "true" : "false"
     );
     await expect(responseSuccessRetriesExhaustedText).toHaveText(
         retriesExhausted
@@ -416,26 +428,26 @@ export const verifyResponseSuccessOverlay = async (
         const responseDataRequest = JSON.parse(
             responseSuccessDataTextAttributes.text
         ).request;
-        if (testHost) {
-            jestExpect(responseDataRequest.headers["host"]).toBe(testHost);
+        if (host) {
+            jestExpect(responseDataRequest.headers["host"]).toBe(host);
         }
-        if (testMethod) {
-            jestExpect(responseDataRequest.method).toBe(testMethod);
+        if (method) {
+            jestExpect(responseDataRequest.method).toBe(method);
         }
 
         // * Verify response body contains request headers
-        if (testHeaders) {
-            for (const [k, v] of Object.entries(testHeaders)) {
+        if (headers) {
+            for (const [k, v] of Object.entries(headers)) {
                 jestExpect(responseDataRequest.headers[k]).toBe(v);
             }
         }
 
         // * Verify response body contains request body
-        if (testBody) {
+        if (body) {
             jestExpect(Object.keys(responseDataRequest.body)).toHaveLength(
-                Object.keys(testBody).length
+                Object.keys(body).length
             );
-            for (const [k, v] of Object.entries(testBody)) {
+            for (const [k, v] of Object.entries(body)) {
                 jestExpect(responseDataRequest.body[k]).toBe(v);
             }
         }
@@ -461,21 +473,18 @@ export const verifyResponseSuccessOverlay = async (
 
 /**
  * Verify response error overlay.
- * @param {number} testErrorCode - the client error code
- * @param {string} testErrorMessage - the client error message
+ * @param {number} errorCode - the client error code
+ * @param {string} errorMessage - the client error message
  */
-export const verifyResponseErrorOverlay = async (
-    testErrorCode,
-    testErrorMessage
-) => {
+export const verifyResponseErrorOverlay = async (errorCode, errorMessage) => {
     const {
         responseErrorCodeText,
         responseErrorMessageText,
     } = ResponseErrorOverlay;
 
     // * Verify response error code and message
-    await expect(responseErrorCodeText).toHaveText(testErrorCode.toString());
-    await expect(responseErrorMessageText).toHaveText(testErrorMessage);
+    await expect(responseErrorCodeText).toHaveText(errorCode.toString());
+    await expect(responseErrorMessageText).toHaveText(errorMessage);
 
     // # Close response error overlay
     await ResponseErrorOverlay.close();
@@ -483,23 +492,19 @@ export const verifyResponseErrorOverlay = async (
 
 /**
  * Verify API client.
- * @param {string} testName - client name
- * @param {string} testUrl - URL of requested server
- * @param {Object} testHeaders - request headers
+ * @param {string} name - client name
+ * @param {string} url - URL of requested server
+ * @param {Object} headers - request headers
  */
-export const verifyApiClient = async (
-    testName,
-    testUrl,
-    testHeaders = null
-) => {
+export const verifyApiClient = async (name, url, headers = null) => {
     const {
         baseUrlInput,
         getHeaderListItemAtIndex,
         nameInput,
     } = ApiClientScreen;
 
-    const headers = testHeaders ? testHeaders : {};
-    const ordered = Object.keys(headers)
+    const unordered = headers ? headers : {};
+    const ordered = Object.keys(unordered)
         .sort()
         .reduce((result, key) => {
             result[key] = headers[key];
@@ -507,8 +512,8 @@ export const verifyApiClient = async (
         }, {});
     const entries = Object.entries(ordered);
     if (isAndroid()) {
-        await expect(nameInput).toHaveText(testName);
-        await expect(baseUrlInput).toHaveText(testUrl);
+        await expect(nameInput).toHaveText(name);
+        await expect(baseUrlInput).toHaveText(url);
 
         for (const [index, [key, value]] of Object.entries(entries)) {
             const { keyInput, valueInput } = getHeaderListItemAtIndex(index);
@@ -516,8 +521,8 @@ export const verifyApiClient = async (
             await expect(valueInput).toHaveText(value);
         }
     } else {
-        await expect(nameInput).toHaveValue(testName);
-        await expect(baseUrlInput).toHaveValue(testUrl);
+        await expect(nameInput).toHaveValue(name);
+        await expect(baseUrlInput).toHaveValue(url);
 
         for (const [index, [key, value]] of Object.entries(entries)) {
             const { keyInput, valueInput } = getHeaderListItemAtIndex(index);

--- a/example/detox/e2e/test/helpers.js
+++ b/example/detox/e2e/test/helpers.js
@@ -3,10 +3,16 @@
 
 import jestExpect from "expect";
 
-import { ResponseSuccessOverlay } from "@support/ui/component";
+import {
+    ResponseErrorOverlay,
+    ResponseSuccessOverlay,
+} from "@support/ui/component";
 import {
     ApiClientRequestScreen,
     ApiClientScreen,
+    ClientListScreen,
+    CreateApiClientScreen,
+    CreateWebSocketClientScreen,
     GenericClientRequestScreen,
     WebSocketClientScreen,
 } from "@support/ui/screen";
@@ -27,24 +33,197 @@ export const customBody = {
 export const retryPolicyTypes = ["exponential", "linear"];
 
 /**
+ * Create API client.
+ * @param {string} testName - client name
+ * @param {string} testBaseUrl - base URL of requested server
+ * @param {Object} testHeaders - request headers
+ * @param {string} testToken - request authentication token
+ * @param {number} testRequestTimeoutInterval - client request timeout interval
+ * @param {number} testResourceTimeoutInterval - client resource timeout interval
+ * @param {number} testMaxConnections - client max connections
+ * @param {Object} testRetry - client retry configuration
+ * @param {string} options.clientCertPassword - secure client certificate password
+ * @param {boolean} options.secure - if server is secure, true; otherwise, false
+ * @param {string} options.secureServerClientCertUrl - secure server client certificate URL
+ * @param {boolean} options.toggleOn - if true, checkboxes are toggled on
+ * @param {boolean} options.verify - if true, client created is verified
+ */
+export const createApiClient = async (
+    testName,
+    testBaseUrl,
+    testHeaders = null,
+    testToken = null,
+    testRequestTimeoutInterval = null,
+    testResourceTimeoutInterval = null,
+    testMaxConnections = null,
+    testRetry = null,
+    {
+        clientCertPassword = null,
+        secure = false,
+        secureServerClientCertUrl = null,
+        toggleOn = false,
+        verify = true,
+    } = {}
+) => {
+    const {
+        createClient,
+        setBaseUrl,
+        setBearerAuthToken,
+        setHeaders,
+        setMaxConnections,
+        setName,
+        setRequestTimeoutInterval,
+        setResourceTimeoutInterval,
+        setRetry,
+        toggleOnCancelRequestsOn401Checkbox,
+        toggleOnTrustSelfSignedServerCertificateCheckbox,
+        toggleOnWaitsForConnectivityCheckbox,
+    } = CreateApiClientScreen;
+
+    // # Open create API client screen
+    await CreateApiClientScreen.open();
+
+    // # Set all fields
+    await setName(testName);
+    await setBaseUrl(testBaseUrl);
+    if (testHeaders) {
+        await setHeaders(testHeaders);
+    }
+    if (testToken) {
+        await setBearerAuthToken(testToken);
+    }
+    if (secure) {
+        await CreateApiClientScreen.downloadP12(
+            secureServerClientCertUrl,
+            clientCertPassword
+        );
+    }
+    if (testRequestTimeoutInterval) {
+        await setRequestTimeoutInterval(testRequestTimeoutInterval);
+    }
+    if (testResourceTimeoutInterval) {
+        await setResourceTimeoutInterval(testResourceTimeoutInterval);
+    }
+    if (testMaxConnections) {
+        await setMaxConnections(testMaxConnections);
+    }
+    if (toggleOn) {
+        await toggleOnWaitsForConnectivityCheckbox();
+        await toggleOnCancelRequestsOn401Checkbox();
+    }
+    if (secure) {
+        await toggleOnTrustSelfSignedServerCertificateCheckbox();
+    }
+    if (testRetry) {
+        await setRetry(testRetry);
+    }
+
+    // # Create client
+    await createClient();
+
+    // * Verify created client
+    if (verify) {
+        await ApiClientScreen.open(testName);
+        await verifyApiClient(testName, testBaseUrl, testHeaders);
+
+        // # Open client list screen
+        await ApiClientScreen.back();
+    }
+};
+
+/**
+ * Create WebSocket client.
+ * @param {string} testName - client name
+ * @param {string} testUrl - URL of requested server
+ * @param {Object} testHeaders - request headers
+ * @param {number} testTimeoutInterval - client request timeout interval
+ * @param {string} options.clientCertPassword - secure client certificate password
+ * @param {boolean} options.secure - if server is secure, true; otherwise, false
+ * @param {string} options.secureServerClientCertUrl - secure server client certificate URL
+ * @param {boolean} options.toggleOn - if true, checkboxes are toggled on
+ * @param {boolean} options.verify - if true, client created is verified
+ */
+export const createWebSocketClient = async (
+    testName,
+    testUrl,
+    testHeaders = null,
+    testTimeoutInterval = null,
+    {
+        clientCertPassword = null,
+        secure = false,
+        secureWebSocketServerClientCertUrl = null,
+        toggleOn = false,
+        verify = true,
+    } = {}
+) => {
+    const {
+        createClient,
+        setHeaders,
+        setName,
+        setTimeoutInterval,
+        setUrl,
+        toggleOnEnableCompressionCheckbox,
+        toggleOnTrustSelfSignedServerCertificateCheckbox,
+    } = CreateWebSocketClientScreen;
+
+    // # Open create WebSocket client screen
+    await CreateWebSocketClientScreen.open();
+
+    // # Set all fields
+    await setName(testName);
+    await setUrl(testUrl);
+    if (testHeaders) {
+        await setHeaders(testHeaders);
+    }
+    if (secure) {
+        await CreateWebSocketClientScreen.downloadP12(
+            secureWebSocketServerClientCertUrl,
+            clientCertPassword
+        );
+    }
+    if (testTimeoutInterval) {
+        await setTimeoutInterval(testTimeoutInterval);
+    }
+    if (toggleOn) {
+        await toggleOnEnableCompressionCheckbox();
+    }
+    if (secure) {
+        await toggleOnTrustSelfSignedServerCertificateCheckbox();
+    }
+
+    // Create client
+    await createClient();
+
+    // * Verify created client
+    if (verify) {
+        const { subtitle, title } = await ClientListScreen.getClientByName(
+            testName
+        );
+        await expect(title).toHaveText(testName);
+        await expect(subtitle).toHaveText(testUrl);
+    }
+};
+
+/**
  * Perform API client request.
  * @param {string} options.testPath - relative or absolute path
  * @param {Object} options.testHeaders - requeset headers
  * @param {Object} options.testBody - request body
- * @param {Object} options.testTimeoutInterval - client timeout interval
+ * @param {number} options.testTimeoutInterval - client timeout interval
  * @param {Object} options.testRetry - client retry
+ * @returns {number} beginTime - timestamp in millis before request is made
  */
 export const performApiClientRequest = async ({
     testPath,
-    testHeaders,
+    testHeaders = null,
     testBody = null,
-    testTimeoutInterval = "60",
+    testTimeoutInterval = 60,
     testRetry = {
         retryPolicyType: getRandomItem(retryPolicyTypes),
-        retryLimit: "3",
-        exponentialBackoffBase: "4",
-        exponentialBackoffScale: "5",
-        retryInterval: "6",
+        retryLimit: 3,
+        exponentialBackoffBase: 4,
+        exponentialBackoffScale: 5,
+        retryInterval: 6,
     },
 }) => {
     const {
@@ -56,17 +235,24 @@ export const performApiClientRequest = async ({
         setTimeoutInterval,
     } = ApiClientRequestScreen;
 
-    // # Set all fields and make request
+    // # Set all fields
     await setPath(testPath);
-    await setHeaders(testHeaders);
+    if (testHeaders) {
+        await setHeaders(testHeaders);
+    }
     if (testBody) {
         await setBody(JSON.stringify(testBody));
     }
-    await setTimeoutInterval(testTimeoutInterval);
-    await setRetry(testRetry);
+    if (testTimeoutInterval) {
+        await setTimeoutInterval(testTimeoutInterval);
+    }
+    if (testRetry) {
+        await setRetry(testRetry);
+    }
+
+    // # Make request
     const beginTime = Date.now();
     await makeRequest();
-
     return beginTime;
 };
 
@@ -75,20 +261,21 @@ export const performApiClientRequest = async ({
  * @param {string} options.testUrl - URL of requested server
  * @param {Object} options.testHeaders - requeset headers
  * @param {Object} options.testBody - request body
- * @param {Object} options.testTimeoutInterval - client timeout interval
+ * @param {number} options.testTimeoutInterval - client timeout interval
  * @param {Object} options.testRetry - client retry
+ * @returns {number} beginTime - timestamp in millis before request is made
  */
 export const performGenericClientRequest = async ({
     testUrl,
-    testHeaders,
+    testHeaders = null,
     testBody = null,
-    testTimeoutInterval = "60",
+    testTimeoutInterval = 60,
     testRetry = {
         retryPolicyType: getRandomItem(retryPolicyTypes),
-        retryLimit: "3",
-        exponentialBackoffBase: "4",
-        exponentialBackoffScale: "5",
-        retryInterval: "6",
+        retryLimit: 3,
+        exponentialBackoffBase: 4,
+        exponentialBackoffScale: 5,
+        retryInterval: 6,
     },
 }) => {
     const {
@@ -100,15 +287,25 @@ export const performGenericClientRequest = async ({
         setUrl,
     } = GenericClientRequestScreen;
 
-    // # Set all fields and make request
+    // # Set all fields
     await setUrl(testUrl);
-    await setHeaders(testHeaders);
+    if (testHeaders) {
+        await setHeaders(testHeaders);
+    }
     if (testBody) {
         await setBody(JSON.stringify(testBody));
     }
-    await setTimeoutInterval(testTimeoutInterval);
-    await setRetry(testRetry);
+    if (testTimeoutInterval) {
+        await setTimeoutInterval(testTimeoutInterval);
+    }
+    if (testRetry) {
+        await setRetry(testRetry);
+    }
+
+    // # Make request
+    const beginTime = Date.now();
     await makeRequest();
+    return beginTime;
 };
 
 /**
@@ -118,7 +315,7 @@ export const performGenericClientRequest = async ({
  * @param {number} testStatus - expected response status code
  * @param {string} testHost - host header value of requested server
  * @param {string} testMethod - request method
- * @param {Object} testHeaders - requeset headers
+ * @param {Object} testHeaders - request headers
  * @param {Object} testBody - request body
  */
 export const verifyApiResponse = async (
@@ -165,8 +362,12 @@ export const verifyApiResponse = async (
  * @param {number} testStatus - expected response status code
  * @param {string} testHost - host header value of requested server
  * @param {string} testMethod - request method
- * @param {Object} testHeaders - requeset headers
+ * @param {Object} testHeaders - request headers
  * @param {Object} testBody - request body
+ * @param {string} options.retriesExhausted - "null", "true", or "false"
+ * @param {boolean} options.secure - if server is secure, true; otherwise, false
+ * @param {string} options.server - server name
+ * @returns {number} endTime - timestamp in millis after response is received
  */
 export const verifyResponseSuccessOverlay = async (
     testUrl,
@@ -185,7 +386,8 @@ export const verifyResponseSuccessOverlay = async (
         responseSuccessOkText,
         responseSuccessRetriesExhaustedText,
     } = ResponseSuccessOverlay;
-    // * Verify request URL and response status
+
+    // * Verify request URL, response code, response status, and retries exhausted
     await waitFor(responseSuccessLastRequestedUrlText)
         .toBeVisible()
         .withTimeout(timeouts.TEN_SEC);
@@ -251,20 +453,56 @@ export const verifyResponseSuccessOverlay = async (
         }
     }
 
+    // # Close response success overlay
+    await ResponseSuccessOverlay.close();
+
     return endTime;
 };
 
-export const verifyApiClient = async (testName, testUrl, testHeaders = {}) => {
+/**
+ * Verify response error overlay.
+ * @param {number} testErrorCode - the client error code
+ * @param {string} testErrorMessage - the client error message
+ */
+export const verifyResponseErrorOverlay = async (
+    testErrorCode,
+    testErrorMessage
+) => {
+    const {
+        responseErrorCodeText,
+        responseErrorMessageText,
+    } = ResponseErrorOverlay;
+
+    // * Verify response error code and message
+    await expect(responseErrorCodeText).toHaveText(testErrorCode.toString());
+    await expect(responseErrorMessageText).toHaveText(testErrorMessage);
+
+    // # Close response error overlay
+    await ResponseErrorOverlay.close();
+};
+
+/**
+ * Verify API client.
+ * @param {string} testName - client name
+ * @param {string} testUrl - URL of requested server
+ * @param {Object} testHeaders - request headers
+ */
+export const verifyApiClient = async (
+    testName,
+    testUrl,
+    testHeaders = null
+) => {
     const {
         baseUrlInput,
         getHeaderListItemAtIndex,
         nameInput,
     } = ApiClientScreen;
 
-    const ordered = Object.keys(testHeaders)
+    const headers = testHeaders ? testHeaders : {};
+    const ordered = Object.keys(headers)
         .sort()
         .reduce((result, key) => {
-            result[key] = testHeaders[key];
+            result[key] = headers[key];
             return result;
         }, {});
     const entries = Object.entries(ordered);
@@ -289,6 +527,10 @@ export const verifyApiClient = async (testName, testUrl, testHeaders = {}) => {
     }
 };
 
+/**
+ * Verify WebSocket event.
+ * @param {Object} eventJson - event as JSON object
+ */
 export const verifyWebSocketEvent = async (eventJson) => {
     // Currently only for iOS. Android getAttributes support is not yet available.
     // https://github.com/wix/Detox/issues/2083
@@ -301,6 +543,13 @@ export const verifyWebSocketEvent = async (eventJson) => {
     }
 };
 
+/**
+ * Verify linear retry time difference.
+ * @param {number} beginTime - the begin time in millis
+ * @param {number} endTime - the end time in millis
+ * @param {number} retryLimit - the retry limit
+ * @param {number} retryInterval - the retry interval in millis
+ */
 export const verifyLinearRetryTimeDiff = (
     beginTime,
     endTime,
@@ -312,6 +561,14 @@ export const verifyLinearRetryTimeDiff = (
     jestExpect(actualTimeDiff).toBeCloseTo(expectedTimeDiff);
 };
 
+/**
+ * Verify exponential retry time difference.
+ * @param {number} beginTime - the begin time in millis
+ * @param {number} endTime - the end time in millis
+ * @param {number} retryLimit - the retry limit
+ * @param {number} exponentialBackoffBase - the exponential backoff base in seconds
+ * @param {number} exponentialBackoffScale - the exponential backoff scale
+ */
 export const verifyExponentialRetryTimeDiff = (
     beginTime,
     endTime,

--- a/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
@@ -82,7 +82,11 @@ describe("Patch - API Client Request", () => {
         await ApiClientScreen.selectPatch();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -124,7 +128,11 @@ describe("Patch - API Client Request", () => {
         await ApiClientScreen.selectPatch();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -155,10 +163,10 @@ describe("Patch - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response
@@ -215,10 +223,10 @@ describe("Patch - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response

--- a/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_api_client_request.e2e.js
@@ -183,7 +183,6 @@ describe("Patch - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay
@@ -245,7 +244,6 @@ describe("Patch - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
@@ -54,9 +54,9 @@ describe("Patch - Generic Client Request", () => {
 
         // # Perform generic client request
         await performGenericClientRequest({
-            testUrl: testServerUrl,
-            testHeaders,
-            testBody,
+            body: testBody,
+            headers: testHeaders,
+            url: testServerUrl,
         });
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/patch/patch_generic_client_request.e2e.js
@@ -28,7 +28,12 @@ describe("Patch - Generic Client Request", () => {
     const testHeaders = { ...customHeaders };
     const testBody = { ...customBody };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return a valid response", async () => {
+        // * Verify direct server response
         const apiResponse = await Request.apiPatch({
             headers: testHeaders,
             body: testBody,
@@ -43,11 +48,10 @@ describe("Patch - Generic Client Request", () => {
             testBody
         );
 
+        // # Select patch
         await GenericClientRequestScreen.open();
         await GenericClientRequestScreen.patchButton.tap();
-    });
 
-    it("should return a valid response", async () => {
         // # Perform generic client request
         await performGenericClientRequest({
             testUrl: testServerUrl,

--- a/example/detox/e2e/test/post/post_api_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_api_client_request.e2e.js
@@ -183,7 +183,6 @@ describe("Post - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay
@@ -245,7 +244,6 @@ describe("Post - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/post/post_api_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_api_client_request.e2e.js
@@ -82,7 +82,11 @@ describe("Post - API Client Request", () => {
         await ApiClientScreen.selectPost();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -124,7 +128,11 @@ describe("Post - API Client Request", () => {
         await ApiClientScreen.selectPost();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -155,10 +163,10 @@ describe("Post - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response
@@ -215,10 +223,10 @@ describe("Post - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response

--- a/example/detox/e2e/test/post/post_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_generic_client_request.e2e.js
@@ -28,7 +28,12 @@ describe("Post - Generic Client Request", () => {
     const testHeaders = { ...customHeaders };
     const testBody = { ...customBody };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return a valid response", async () => {
+        // * Verify direct server response
         const apiResponse = await Request.apiPost({
             headers: testHeaders,
             body: testBody,
@@ -43,11 +48,10 @@ describe("Post - Generic Client Request", () => {
             testBody
         );
 
+        // # Select post
         await GenericClientRequestScreen.open();
         await GenericClientRequestScreen.postButton.tap();
-    });
 
-    it("should return a valid response", async () => {
         // # Perform generic client request
         await performGenericClientRequest({
             testUrl: testServerUrl,

--- a/example/detox/e2e/test/post/post_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/post/post_generic_client_request.e2e.js
@@ -54,9 +54,9 @@ describe("Post - Generic Client Request", () => {
 
         // # Perform generic client request
         await performGenericClientRequest({
-            testUrl: testServerUrl,
-            testHeaders,
-            testBody,
+            body: testBody,
+            headers: testHeaders,
+            url: testServerUrl,
         });
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/put/put_api_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_api_client_request.e2e.js
@@ -82,7 +82,11 @@ describe("Put - API Client Request", () => {
         await ApiClientScreen.selectPut();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -124,7 +128,11 @@ describe("Put - API Client Request", () => {
         await ApiClientScreen.selectPut();
 
         // # Perform API client request
-        await performApiClientRequest({ testPath, testHeaders, testBody });
+        await performApiClientRequest({
+            body: testBody,
+            headers: testHeaders,
+            path: testPath,
+        });
 
         // * Verify response success overlay
         await verifyResponseSuccessOverlay(
@@ -155,10 +163,10 @@ describe("Put - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response
@@ -215,10 +223,10 @@ describe("Put - API Client Request", () => {
         const clientID = getRandomId();
         const testRetryPath = `${testPath}/retry/clientID/${clientID}/serverDelay/0/serverRetryLimit/5`;
         const beginTime = await performApiClientRequest({
-            testPath: testRetryPath,
-            testHeaders,
-            testBody,
-            testRetry,
+            body: testBody,
+            headers: testHeaders,
+            path: testRetryPath,
+            retry: testRetry,
         });
 
         // * Verify retry response

--- a/example/detox/e2e/test/put/put_api_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_api_client_request.e2e.js
@@ -183,7 +183,6 @@ describe("Put - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay
@@ -245,7 +244,6 @@ describe("Put - API Client Request", () => {
         );
 
         // # Make another request
-        await ApiClientRequestScreen.responseSuccessCloseButton.tap();
         await ApiClientRequestScreen.makeRequest();
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/put/put_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_generic_client_request.e2e.js
@@ -28,7 +28,12 @@ describe("Put - Generic Client Request", () => {
     const testHeaders = { ...customHeaders };
     const testBody = { ...customBody };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return a valid response", async () => {
+        // * Verify direct server response
         const apiResponse = await Request.apiPut({
             headers: testHeaders,
             body: testBody,
@@ -43,11 +48,10 @@ describe("Put - Generic Client Request", () => {
             testBody
         );
 
+        // # Select put
         await GenericClientRequestScreen.open();
         await GenericClientRequestScreen.putButton.tap();
-    });
 
-    it("should return a valid response", async () => {
         // # Perform generic client request
         await performGenericClientRequest({
             testUrl: testServerUrl,

--- a/example/detox/e2e/test/put/put_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/put/put_generic_client_request.e2e.js
@@ -54,9 +54,9 @@ describe("Put - Generic Client Request", () => {
 
         // # Perform generic client request
         await performGenericClientRequest({
-            testUrl: testServerUrl,
-            testHeaders,
-            testBody,
+            body: testBody,
+            headers: testHeaders,
+            url: testServerUrl,
         });
 
         // * Verify response success overlay

--- a/example/detox/e2e/test/setup/create_api_client.e2e.js
+++ b/example/detox/e2e/test/setup/create_api_client.e2e.js
@@ -40,17 +40,17 @@ describe("Create API Client", () => {
 
     it("should be able to create, alert for duplicate, and remove an API client", async () => {
         // Create API client
-        await createApiClient(
-            testName,
-            testBaseUrl,
-            testHeaders,
-            testToken,
-            testRequestTimeoutInterval,
-            testResourceTimeoutInterval,
-            testMaxConnections,
-            testRetry,
-            { secure: false }
-        );
+        await createApiClient({
+            baseUrl: testBaseUrl,
+            headers: testHeaders,
+            maxConnections: testMaxConnections,
+            name: testName,
+            requestTimeoutInterval: testRequestTimeoutInterval,
+            resourceTimeoutInterval: testResourceTimeoutInterval,
+            retry: testRetry,
+            secure: false,
+            token: testToken,
+        });
 
         // Alert for duplicate API client
         await alertForDuplicateApiClient(testName, testBaseUrl);
@@ -66,17 +66,19 @@ describe("Create API Client", () => {
         // Create API client
         const testSecureName = `Secure ${testName}`;
         const testSecureBaseUrl = secureServerUrl;
-        await createApiClient(
-            testSecureName,
-            testSecureBaseUrl,
-            testHeaders,
-            testToken,
-            testRequestTimeoutInterval,
-            testResourceTimeoutInterval,
-            testMaxConnections,
-            testRetry,
-            { clientCertPassword, secure: true, secureServerClientCertUrl }
-        );
+        await createApiClient({
+            baseUrl: testSecureBaseUrl,
+            clientCertPassword,
+            headers: testHeaders,
+            maxConnections: testMaxConnections,
+            name: testSecureName,
+            requestTimeoutInterval: testRequestTimeoutInterval,
+            resourceTimeoutInterval: testResourceTimeoutInterval,
+            retry: testRetry,
+            secure: true,
+            secureServerClientCertUrl,
+            token: testToken,
+        });
 
         // Alert for duplicate API client
         await alertForDuplicateApiClient(testSecureName, testSecureBaseUrl);
@@ -90,17 +92,11 @@ async function alertForDuplicateApiClient(testName, testBaseUrl) {
     const { errorTitle, okButton } = Alert;
 
     // # Set an existing url and attempt to create client
-    await createApiClient(
-        testName,
-        testBaseUrl,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        { verify: false }
-    );
+    await createApiClient({
+        baseUrl: testBaseUrl,
+        name: testName,
+        verify: false,
+    });
 
     // * Verify error alert
     await expect(errorTitle).toBeVisible();

--- a/example/detox/e2e/test/setup/create_websocket_client.e2e.js
+++ b/example/detox/e2e/test/setup/create_websocket_client.e2e.js
@@ -33,13 +33,13 @@ describe("Create WebSocket Client", () => {
 
     it("should be able to create, alert for duplicate, and remove a WebSocket client", async () => {
         // # Create WebSocket client
-        await createWebSocketClient(
-            testName,
-            testUrl,
-            testHeaders,
-            testTimeoutInterval,
-            { secure: false }
-        );
+        await createWebSocketClient({
+            headers: testHeaders,
+            name: testName,
+            secure: false,
+            timeoutInterval: testTimeoutInterval,
+            url: testUrl,
+        });
 
         // # Alert for duplicate WebSocket client
         await alertForDuplicateWebSocketClient(testName, testUrl);
@@ -52,17 +52,15 @@ describe("Create WebSocket Client", () => {
         // # Create WebSocket client
         const testSecureName = `Secure ${testName}`;
         const testSecureUrl = secureWebSocketServerUrl;
-        await createWebSocketClient(
-            testSecureName,
-            testSecureUrl,
-            testHeaders,
-            testTimeoutInterval,
-            {
-                clientCertPassword,
-                secure: true,
-                secureWebSocketServerClientCertUrl,
-            }
-        );
+        await createWebSocketClient({
+            clientCertPassword,
+            headers: testHeaders,
+            name: testSecureName,
+            secure: true,
+            secureWebSocketServerClientCertUrl,
+            timeoutInterval: testTimeoutInterval,
+            url: testSecureUrl,
+        });
 
         // # Alert for duplicate WebSocket client
         await alertForDuplicateWebSocketClient(testSecureName, testSecureUrl);
@@ -76,7 +74,9 @@ async function alertForDuplicateWebSocketClient(testName, testUrl) {
     const { errorTitle, okButton } = Alert;
 
     // # Set an existing url and attempt to create client
-    await createWebSocketClient(testName, testUrl, null, null, {
+    await createWebSocketClient({
+        name: testName,
+        url: testUrl,
         verify: false,
     });
 

--- a/example/detox/e2e/test/setup/error_api_client_request.e2e.js
+++ b/example/detox/e2e/test/setup/error_api_client_request.e2e.js
@@ -26,15 +26,15 @@ describe("Error - API Client Request", () => {
         const testBaseUrl = process.env.IOS
             ? "http://127.0.0.1"
             : "http://10.0.2.2";
-        await createApiClient(testName, testBaseUrl);
+        await createApiClient({ baseUrl: testBaseUrl, name: testName });
         await ApiClientScreen.open(testName);
         await ApiClientScreen.selectGet();
 
         // # Perform API client request
         await performApiClientRequest({
-            testPath: "/",
-            testTimeoutInterval: null,
-            testRetry: null,
+            path: "/",
+            timeoutInterval: null,
+            retry: null,
         });
 
         // * Verify response error overlay

--- a/example/detox/e2e/test/setup/error_api_client_request.e2e.js
+++ b/example/detox/e2e/test/setup/error_api_client_request.e2e.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import { ApiClientScreen } from "@support/ui/screen";
+import { getRandomId } from "@support/utils";
+import {
+    createApiClient,
+    performApiClientRequest,
+    verifyResponseErrorOverlay,
+} from "../helpers";
+
+describe("Error - API Client Request", () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return an error response when server is unreachable", async () => {
+        // # Create API client and select method
+        const testName = `Example ${getRandomId(10)} API`;
+        const testBaseUrl = process.env.IOS
+            ? "http://127.0.0.1"
+            : "http://10.0.2.2";
+        await createApiClient(testName, testBaseUrl);
+        await ApiClientScreen.open(testName);
+        await ApiClientScreen.selectGet();
+
+        // # Perform API client request
+        await performApiClientRequest({
+            testPath: "/",
+            testTimeoutInterval: null,
+            testRetry: null,
+        });
+
+        // * Verify response error overlay
+        await verifyResponseErrorOverlay(
+            13,
+            "URLSessionTask failed with error: Could not connect to the server."
+        );
+    });
+});

--- a/example/detox/e2e/test/setup/error_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/setup/error_generic_client_request.e2e.js
@@ -28,9 +28,9 @@ describe("Error - Generic Client Request", () => {
             ? "http://127.0.0.1"
             : "http://10.0.2.2";
         await performGenericClientRequest({
-            testUrl,
-            testTimeoutInterval: null,
-            testRetry: null,
+            retry: null,
+            timeoutInterval: null,
+            url: testUrl,
         });
 
         // * Verify response error overlay

--- a/example/detox/e2e/test/setup/error_generic_client_request.e2e.js
+++ b/example/detox/e2e/test/setup/error_generic_client_request.e2e.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *******************************************************************
+// - [#] indicates a test step (e.g. # Go to a screen)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element testID when selecting an element. Create one if none.
+// *******************************************************************
+
+import { GenericClientRequestScreen } from "@support/ui/screen";
+import {
+    performGenericClientRequest,
+    verifyResponseErrorOverlay,
+} from "../helpers";
+
+describe("Error - Generic Client Request", () => {
+    beforeEach(async () => {
+        await device.reloadReactNative();
+    });
+
+    it("should return an error response when server is unreachable", async () => {
+        // # Select method
+        await GenericClientRequestScreen.open();
+        await GenericClientRequestScreen.getButton.tap();
+
+        // # Perform generic client request
+        const testUrl = process.env.IOS
+            ? "http://127.0.0.1"
+            : "http://10.0.2.2";
+        await performGenericClientRequest({
+            testUrl,
+            testTimeoutInterval: null,
+            testRetry: null,
+        });
+
+        // * Verify response error overlay
+        await verifyResponseErrorOverlay(
+            13,
+            "URLSessionTask failed with error: Could not connect to the server."
+        );
+    });
+});

--- a/example/detox/e2e/test/websocket/websocket_client_request.e2e.js
+++ b/example/detox/e2e/test/websocket/websocket_client_request.e2e.js
@@ -13,12 +13,8 @@ import {
     secureWebSocketServerUrl,
     webSocketServerUrl,
 } from "@support/test_config";
-import {
-    ClientListScreen,
-    CreateWebSocketClientScreen,
-    WebSocketClientScreen,
-} from "@support/ui/screen";
-import { verifyWebSocketEvent } from "../helpers";
+import { WebSocketClientScreen } from "@support/ui/screen";
+import { createWebSocketClient, verifyWebSocketEvent } from "../helpers";
 
 describe("WebSocket Client Request", () => {
     const testName = "Simple WebSocket";
@@ -52,10 +48,16 @@ describe("WebSocket Client Request", () => {
 
     it("should be able to connect, send message, and disconnect - secure connection", async () => {
         // # Create secure WebSocket client
-        await CreateWebSocketClientScreen.open();
-        await createSecureWebSocketClient(
+        await createWebSocketClient(
             testSecureName,
-            testSecureWebSocketUrl
+            testSecureWebSocketUrl,
+            null,
+            null,
+            {
+                clientCertPassword,
+                secure: true,
+                secureWebSocketServerClientCertUrl,
+            }
         );
 
         // # Open client
@@ -113,31 +115,4 @@ async function connectSendMessageAndDisconnect(
 
     // # Open client list screen
     await WebSocketClientScreen.back();
-}
-
-async function createSecureWebSocketClient(
-    testSecureName,
-    testSecureWebSocketUrl
-) {
-    const {
-        createClient,
-        downloadP12,
-        setName,
-        setUrl,
-        toggleOnTrustSelfSignedServerCertificateCheckbox,
-    } = CreateWebSocketClientScreen;
-
-    // # Set all fields and create client
-    await setName(testSecureName);
-    await setUrl(testSecureWebSocketUrl);
-    await downloadP12(secureWebSocketServerClientCertUrl, clientCertPassword);
-    await toggleOnTrustSelfSignedServerCertificateCheckbox();
-    await createClient();
-
-    // * Verify created client
-    const { subtitle, title } = await ClientListScreen.getClientByName(
-        testSecureName
-    );
-    await expect(title).toHaveText(testSecureName);
-    await expect(subtitle).toHaveText(testSecureWebSocketUrl);
 }

--- a/example/detox/e2e/test/websocket/websocket_client_request.e2e.js
+++ b/example/detox/e2e/test/websocket/websocket_client_request.e2e.js
@@ -48,17 +48,13 @@ describe("WebSocket Client Request", () => {
 
     it("should be able to connect, send message, and disconnect - secure connection", async () => {
         // # Create secure WebSocket client
-        await createWebSocketClient(
-            testSecureName,
-            testSecureWebSocketUrl,
-            null,
-            null,
-            {
-                clientCertPassword,
-                secure: true,
-                secureWebSocketServerClientCertUrl,
-            }
-        );
+        await createWebSocketClient({
+            clientCertPassword,
+            name: testSecureName,
+            secure: true,
+            secureWebSocketServerClientCertUrl,
+            url: testSecureWebSocketUrl,
+        });
 
         // # Open client
         await WebSocketClientScreen.open(testSecureName);


### PR DESCRIPTION
#### Summary
- Added sample tests for client errors
    - `example/detox/e2e/test/setup/error_api_client_request.e2e.js`
    - `example/detox/e2e/test/setup/error_generic_client_request.e2e.js`
- Added `verifyResponseErrorOverlay` to `helpers.js`
- The rest of the changes are minor improvements
    - Made sure numerical parameters are passed as numbers instead of string
    - Refactored `createApiClient` and `createWebSocketClient` to `helpers.js`
    - Added/fixed function comments on `helpers.js`
    - Updated affected tests and some cleanup

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34139

Note: `patch/post` failing tests are known issues (fix is being worked here: https://github.com/mattermost/react-native-network-client/pull/53)
![Screen Shot 2021-04-14 at 5 34 53 PM](https://user-images.githubusercontent.com/487991/114799336-41167c00-9d4c-11eb-9a8e-5dac8e1cc328.png)
