### PR TITLE
[MM-30594, MM-34376] Android: Client certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ const { client: wsClient, created } = await getOrCreateWebSocketClient(
 );
 ```
 
+## Self-signed server certificate
+
+To allow usage of self-signed server certificates you can pass in `sessionConfiguration.trustSelfSignedServerCertificate = true` in the options when creating an APIClient. It is recommended **not** to do this in production code as not only will the certificate be trusted, but the hostname will not be verified against your APIClient `baseUrl`'s hostname. This can open you up to man-in-the-middle attacks.
+
 ## Errors
 
 There are two cases where errors will be returned by the native code. The first is via rejected promises and the second is via events.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,4 +128,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.squareup.okhttp3:okhttp:4.9.1"
+  implementation "com.squareup.okhttp3:okhttp-tls:4.9.1"
 }

--- a/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
@@ -23,6 +23,7 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     }
 
     companion object {
+        lateinit var context: ReactApplicationContext
         private val clients = mutableMapOf<HttpUrl, NetworkClient>()
         private val calls = mutableMapOf<String, Call>()
         private lateinit var sharedPreferences: SharedPreferences
@@ -43,15 +44,15 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
             return null
         }
 
-        fun storeToken(value: String, baseUrl: String) {
+        fun storeValue(value: String, alias: String) {
             val encryptedValue = KeyStoreHelper.encryptData(value)
             sharedPreferences.edit()
-                .putString(baseUrl, encryptedValue)
+                .putString(alias, encryptedValue)
                 .apply()
         }
 
-        fun retrieveToken(baseUrl: String): String? {
-            val encryptedData = sharedPreferences.getString(baseUrl, null)
+        fun retrieveValue(alias: String): String? {
+            val encryptedData = sharedPreferences.getString(alias, null)
             if (encryptedData != null) {
                 return KeyStoreHelper.decryptData(encryptedData)
             }
@@ -59,10 +60,14 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
             return null
         }
 
-        fun deleteToken(baseUrl: String) {
+        fun deleteValue(alias: String) {
             sharedPreferences.edit()
-                    .remove(baseUrl)
+                    .remove(alias)
                     .apply()
+        }
+
+        private fun setCtx(reactContext: ReactApplicationContext) {
+            context = reactContext
         }
 
         private fun setSharedPreferences(reactContext: ReactApplicationContext) {
@@ -76,6 +81,7 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     }
 
     init {
+        setCtx(reactContext)
         setSharedPreferences(reactContext)
         setCookieJar(reactContext)
     }
@@ -146,7 +152,7 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         }
 
         try {
-            clients[url]!!.importClientP12(path, password)
+            clients[url]!!.importClientP12AndRebuildClient(path, password)
             promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)

--- a/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
@@ -137,6 +137,23 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
     }
 
     @ReactMethod
+    fun importClientP12For(baseUrl: String, path: String, password: String, promise: Promise) {
+        var url: HttpUrl
+        try {
+            url = baseUrl.toHttpUrl()
+        } catch (error: IllegalArgumentException) {
+            return promise.reject(error)
+        }
+
+        try {
+            clients[url]!!.importClientP12(path, password)
+            promise.resolve(null)
+        } catch (error: Exception) {
+            promise.reject(error)
+        }
+    }
+
+    @ReactMethod
     fun invalidateClientFor(baseUrl: String, promise: Promise) {
         var url: HttpUrl
         try {

--- a/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
@@ -1,21 +1,24 @@
 package com.mattermost.networkclient
 
-import com.mattermost.networkclient.enums.APIClientEvents
-import com.mattermost.networkclient.enums.RetryTypes
-import com.mattermost.networkclient.helpers.ProgressListener
-import com.mattermost.networkclient.helpers.UploadFileRequestBody
-import com.mattermost.networkclient.helpers.KeyStoreHelper
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
 import com.facebook.react.bridge.*
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.modules.network.ForwardingCookieHandler
 import com.facebook.react.modules.network.ReactCookieJarContainer
-import okhttp3.*
+import com.mattermost.networkclient.enums.APIClientEvents
+import com.mattermost.networkclient.enums.RetryTypes
+import com.mattermost.networkclient.helpers.KeyStoreHelper
+import com.mattermost.networkclient.helpers.ProgressListener
+import com.mattermost.networkclient.helpers.UploadFileRequestBody
+import okhttp3.Call
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import android.content.SharedPreferences
-import android.content.Context
-import android.net.Uri
-import java.lang.Exception
-import kotlin.collections.HashMap
+import okhttp3.JavaNetCookieJar
+import okhttp3.Request
+
 
 class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
     override fun getName(): String {
@@ -33,7 +36,7 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
         fun getClientForRequest(request: Request): NetworkClient? {
             var urlParts = request.url.toString().split("/")
             while (urlParts.isNotEmpty()) {
-                val url = urlParts.joinToString (separator = "/") { it }.toHttpUrlOrNull()
+                val url = urlParts.joinToString(separator = "/") { it }.toHttpUrlOrNull()
                 if (url !== null && clients.containsKey(url)) {
                     return clients[url]!!
                 }
@@ -64,6 +67,11 @@ class APIClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
             sharedPreferences.edit()
                     .remove(alias)
                     .apply()
+        }
+
+        fun sendJSEvent(eventName: String, params: WritableMap?) {
+            context.getJSModule(RCTDeviceEventEmitter::class.java)
+                    .emit(eventName, params)
         }
 
         private fun setCtx(reactContext: ReactApplicationContext) {

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -57,11 +57,11 @@ fun String.trimTrailingSlashes(): String {
 }
 
 /**
- * Computes the MD5 of a string
+ * Computes the SHA-256 hash of a string
  */
-fun String.md5(): String {
-    val md = MessageDigest.getInstance("MD5")
-    return BigInteger(1, md.digest(toByteArray()))
-            .toString(16)
-            .padStart(32, '0')
+fun String.sha256(): String {
+    return MessageDigest
+            .getInstance("SHA-256")
+            .digest(toByteArray())
+            .fold("", { str, it -> str + "%02x".format(it) })
 }

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -50,6 +50,13 @@ fun Request.Builder.applyHeaders(headers: ReadableMap?): Request.Builder {
 }
 
 /**
+ * Trims trailing slashes in the string
+ */
+fun String.trimTrailingSlashes(): String {
+    return trimEnd { c -> c == '/' }
+}
+
+/**
  * Computes the MD5 of a string
  */
 fun String.md5(): String {

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -5,6 +5,8 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import okhttp3.Request
 import okhttp3.Response
+import java.math.BigInteger
+import java.security.MessageDigest
 
 var Response.retriesExhausted: Boolean? by NetworkClient.RequestRetriesExhausted
 
@@ -45,4 +47,14 @@ fun Request.Builder.applyHeaders(headers: ReadableMap?): Request.Builder {
     }
 
     return this;
+}
+
+/**
+ * Computes the MD5 of a string
+ */
+fun String.md5(): String {
+    val md = MessageDigest.getInstance("MD5")
+    return BigInteger(1, md.digest(toByteArray()))
+            .toString(16)
+            .padStart(32, '0')
 }

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -303,6 +303,8 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
     }
 
     private fun importClientP12(p12FilePath: String, password: String) {
+        // KeyStoreHelper.importClientCertificateFromP12 can throw an exception
+        // and we leave it up to the caller of `importClientP12` to handle it.
         val contentUri = Uri.parse(p12FilePath)
         val realPath = DocumentHelper.getRealPath(contentUri)
         KeyStoreHelper.importClientCertificateFromP12(realPath, password, P12_ALIAS)

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -30,9 +30,9 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
     private val builder: OkHttpClient.Builder = OkHttpClient().newBuilder()
 
     private val BASE_URL_STRING = baseUrl.toString().trimTrailingSlashes()
-    private val BASE_URL_MD5 = BASE_URL_STRING.md5()
-    private val TOKEN_ALIAS = "$BASE_URL_MD5-TOKEN"
-    private val P12_ALIAS = "$BASE_URL_MD5-P12"
+    private val BASE_URL_HASH = BASE_URL_STRING.sha256()
+    private val TOKEN_ALIAS = "$BASE_URL_HASH-TOKEN"
+    private val P12_ALIAS = "$BASE_URL_HASH-P12"
 
     companion object RequestRetriesExhausted {
         private val requestRetriesExhausted: HashMap<Response, Boolean?> = hashMapOf()

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -302,9 +302,14 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
         return builder.build()
     }
 
+    /**
+     * Gets the real path to the p12 file uses KeyStoreHelper to import
+     * the key and certificates.
+     *
+     * @throws Exception from KeyStoreHelper.importClientCertificateFromP12
+     * which we leave to the caller of this function to handle.
+     */
     private fun importClientP12(p12FilePath: String, password: String) {
-        // KeyStoreHelper.importClientCertificateFromP12 can throw an exception
-        // and we leave it up to the caller of `importClientP12` to handle it.
         val contentUri = Uri.parse(p12FilePath)
         val realPath = DocumentHelper.getRealPath(contentUri)
         KeyStoreHelper.importClientCertificateFromP12(realPath, password, P12_ALIAS)

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -1,7 +1,6 @@
 package com.mattermost.networkclient
 
 import android.net.Uri
-import android.util.Log
 import android.webkit.CookieManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap

--- a/android/src/main/java/com/mattermost/networkclient/enums/APIClientEvents.kt
+++ b/android/src/main/java/com/mattermost/networkclient/enums/APIClientEvents.kt
@@ -2,5 +2,5 @@ package com.mattermost.networkclient.enums
 
 enum class APIClientEvents(val event: String) {
     UPLOAD_PROGRESS("APIClient-UploadProgress"),
-    CLIENT_CERTIFICATE_MISSING("APIClient-Client-Certificate-Missing"),
+    CLIENT_ERROR("APIClient-Error"),
 }

--- a/android/src/main/java/com/mattermost/networkclient/helpers/DocumentHelper.java
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/DocumentHelper.java
@@ -86,7 +86,7 @@ public class DocumentHelper {
         return null;
     }
 
-    public static String getPathFromSavingTempFile(Context context, final Uri uri) {
+    private static String getPathFromSavingTempFile(Context context, final Uri uri) {
         File tmpFile;
         String fileName = null;
 
@@ -133,7 +133,7 @@ public class DocumentHelper {
         return tmpFile.getAbsolutePath();
     }
 
-    public static String getDataColumn(Context context, Uri uri, String selection,
+    private static String getDataColumn(Context context, Uri uri, String selection,
                                        String[] selectionArgs) {
         Cursor cursor = null;
         final String column = "_data";
@@ -156,23 +156,23 @@ public class DocumentHelper {
     }
 
 
-    public static boolean isExternalStorageDocument(Uri uri) {
+    private static boolean isExternalStorageDocument(Uri uri) {
         return "com.android.externalstorage.documents".equals(uri.getAuthority());
     }
 
-    public static boolean isDownloadsDocument(Uri uri) {
+    private static boolean isDownloadsDocument(Uri uri) {
         return "com.android.providers.downloads.documents".equals(uri.getAuthority());
     }
 
-    public static boolean isMediaDocument(Uri uri) {
+    private static boolean isMediaDocument(Uri uri) {
         return "com.android.providers.media.documents".equals(uri.getAuthority());
     }
 
-    public static boolean isGooglePhotosUri(Uri uri) {
+    private static boolean isGooglePhotosUri(Uri uri) {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
     }
 
-    public static String getExtension(String uri) {
+    private static String getExtension(String uri) {
         if (uri == null) {
             return null;
         }
@@ -186,7 +186,7 @@ public class DocumentHelper {
         }
     }
 
-    public static String getMimeType(File file) {
+    private static String getMimeType(File file) {
 
         String extension = getExtension(file.getName());
 
@@ -196,7 +196,7 @@ public class DocumentHelper {
         return "application/octet-stream";
     }
 
-    public static String getMimeType(String filePath) {
+    private static String getMimeType(String filePath) {
         File file = new File(filePath);
         return getMimeType(file);
     }

--- a/android/src/main/java/com/mattermost/networkclient/helpers/DocumentHelper.java
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/DocumentHelper.java
@@ -1,0 +1,212 @@
+package com.mattermost.networkclient.helpers;
+
+import com.mattermost.networkclient.APIClientModule;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Environment;
+import android.os.ParcelFileDescriptor;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+public class DocumentHelper {
+    private final static Context context = APIClientModule.context;
+    private final static String CACHE_DIR_NAME = "NetworkClientCacheDir";
+
+    public static String getRealPath(final Uri uri) {
+        if (DocumentsContract.isDocumentUri(context, uri)) {
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+            } else if (isDownloadsDocument(uri)) {
+                final String id = DocumentsContract.getDocumentId(uri);
+                if (!TextUtils.isEmpty(id)) {
+                    if (id.startsWith("raw:")) {
+                        return id.replaceFirst("raw:", "");
+                    }
+                    try {
+                        return getPathFromSavingTempFile(context, uri);
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                }
+            } else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                if (contentUri != null) {
+                    return getDataColumn(context, contentUri, selection, selectionArgs);
+                } else {
+                    return getPathFromSavingTempFile(context, uri);
+                }
+            }
+        }
+
+        if ("content".equalsIgnoreCase(uri.getScheme())) {
+            if (isGooglePhotosUri(uri)) {
+                return uri.getLastPathSegment();
+            }
+
+            return getPathFromSavingTempFile(context, uri);
+        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    public static String getPathFromSavingTempFile(Context context, final Uri uri) {
+        File tmpFile;
+        String fileName = null;
+
+        if (uri == null || uri.isRelative()) {
+            return null;
+        }
+
+        try {
+            Cursor returnCursor =
+                    context.getContentResolver().query(uri, null, null, null, null);
+            int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+            returnCursor.moveToFirst();
+            fileName = sanitizeFilename(returnCursor.getString(nameIndex));
+
+        } catch (Exception e) {
+            // just continue to get the filename with the last segment of the path
+        }
+
+        try {
+            if (TextUtils.isEmpty(fileName)) {
+                fileName = sanitizeFilename(uri.getLastPathSegment().toString().trim());
+            }
+
+
+            File cacheDir = new File(context.getCacheDir(), CACHE_DIR_NAME);
+            if (!cacheDir.exists()) {
+                cacheDir.mkdirs();
+            }
+
+            String mimeType = getMimeType(uri.getPath());
+            tmpFile = new File(cacheDir, fileName);
+            tmpFile.createNewFile();
+
+            ParcelFileDescriptor pfd = context.getContentResolver().openFileDescriptor(uri, "r");
+
+            FileChannel src = new FileInputStream(pfd.getFileDescriptor()).getChannel();
+            FileChannel dst = new FileOutputStream(tmpFile).getChannel();
+            dst.transferFrom(src, 0, src.size());
+            src.close();
+            dst.close();
+        } catch (IOException ex) {
+            return null;
+        }
+        return tmpFile.getAbsolutePath();
+    }
+
+    public static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    public static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+
+    public static String getExtension(String uri) {
+        if (uri == null) {
+            return null;
+        }
+
+        int dot = uri.lastIndexOf(".");
+        if (dot >= 0) {
+            return uri.substring(dot);
+        } else {
+            // No extension.
+            return "";
+        }
+    }
+
+    public static String getMimeType(File file) {
+
+        String extension = getExtension(file.getName());
+
+        if (extension.length() > 0)
+            return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.substring(1));
+
+        return "application/octet-stream";
+    }
+
+    public static String getMimeType(String filePath) {
+        File file = new File(filePath);
+        return getMimeType(file);
+    }
+
+    private static String sanitizeFilename(String filename) {
+        if (filename == null) {
+            return null;
+        }
+
+        File f = new File(filename);
+        return f.getName();
+    }
+}

--- a/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
-import android.util.Log
 import com.mattermost.networkclient.APIClientModule
 import okhttp3.tls.HeldCertificate
 import java.io.FileInputStream
@@ -66,26 +65,21 @@ object KeyStoreHelper {
     }
 
     fun importClientCertificateFromP12(p12FilePath: String, password: String, p12Alias: String) {
-        try {
-            val p12Store = KeyStore.getInstance("PKCS12").apply {
-                load(FileInputStream(p12FilePath), password.toCharArray())
-            }
-            val aliases = p12Store.aliases()
-            while (aliases.hasMoreElements()) {
-                val alias = aliases.nextElement()
-                if (p12Store.isKeyEntry(alias)) {
-                    val key = p12Store.getKey(alias, password.toCharArray())
-                    val certificate = p12Store.getCertificate(alias)
-                    val intermediates = p12Store.getCertificateChain(alias)
+        val p12Store = KeyStore.getInstance("PKCS12").apply {
+            load(FileInputStream(p12FilePath), password.toCharArray())
+        }
+        val aliases = p12Store.aliases()
+        while (aliases.hasMoreElements()) {
+            val alias = aliases.nextElement()
+            if (p12Store.isKeyEntry(alias)) {
+                val key = p12Store.getKey(alias, password.toCharArray())
+                val certificate = p12Store.getCertificate(alias)
+                val intermediates = p12Store.getCertificateChain(alias)
 
-                    storeP12Contents(key, certificate, intermediates, password, p12Alias)
+                storeP12Contents(key, certificate, intermediates, password, p12Alias)
 
-                    break
-                }
+                break
             }
-        } catch (e: Exception) {
-            Log.d("MIGUEL EXCEPTION", "IMPORTING")
-            throw e
         }
     }
 
@@ -110,8 +104,6 @@ object KeyStoreHelper {
                         .toTypedArray()
 
                 return Pair(heldCertificate, intermediates)
-            } else {
-                Log.d("MIGUEL NO CERTIFICATES", keyAlias)
             }
         }
 

--- a/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
@@ -1,11 +1,19 @@
 package com.mattermost.networkclient.helpers
 
+import android.content.Context
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
+import android.util.Log
+import com.mattermost.networkclient.APIClientModule
+import okhttp3.tls.HeldCertificate
 import java.io.FileInputStream
+import java.security.Key
+import java.security.KeyPair
 import java.security.KeyStore
+import java.security.PrivateKey
 import java.security.cert.Certificate
+import java.security.cert.X509Certificate
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -13,21 +21,24 @@ import javax.crypto.spec.IvParameterSpec
 
 
 object KeyStoreHelper {
-    private const val KEY_STORE_TYPE = "AndroidKeyStore"
-    private const val SECRET_KEY_ALIAS = "NetworkClientKeyStore"
+    private const val ANDROID_KEY_STORE_TYPE = "AndroidKeyStore"
+    private const val ANDROID_KEY_ALIAS = "NetworkClientAndroidKeyStore"
+    private lateinit var androidKeyStore: KeyStore
+    private var androidKeyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEY_STORE_TYPE
+    )
+
     private const val CIPHER_TRANSFORMATION = KeyProperties.KEY_ALGORITHM_AES +
             "/" + KeyProperties.BLOCK_MODE_CBC +
             "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7
 
-    private lateinit var keyStore: KeyStore
-    private var keyGenerator = KeyGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_AES,
-            KEY_STORE_TYPE
-    )
+    private const val P12_KEY_ALIAS = "KEY"
+    private const val P12_CERTIFICATE_ALIAS= "CERTIFICATE"
 
     init {
-        setAndLoadKeyStore()
-        generateSecretKeyPairIfNeeded()
+         loadAndroidKeyStore()
+         generateAndroidKeyIfNeeded()
     }
 
     fun encryptData(data: String): String {
@@ -37,7 +48,7 @@ object KeyStoreHelper {
         }
 
         val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
-        cipher.init(Cipher.ENCRYPT_MODE, getSecretKey()!!)
+        cipher.init(Cipher.ENCRYPT_MODE, getAndroidKey()!!)
         val ivBytes = cipher.iv
         val encryptedBytes = cipher.doFinal(temp.toByteArray(Charsets.UTF_8))
 
@@ -49,63 +60,117 @@ object KeyStoreHelper {
         val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
         val (encryptedData, ivData) = data.split(",")
         val spec = IvParameterSpec(Base64.decode(ivData, Base64.DEFAULT))
-        cipher.init(Cipher.DECRYPT_MODE, getSecretKey()!!, spec)
+        cipher.init(Cipher.DECRYPT_MODE, getAndroidKey()!!, spec)
 
         return cipher.doFinal(Base64.decode(encryptedData, Base64.DEFAULT)).toString(Charsets.UTF_8).trim()
     }
 
-    fun importCertificatesFromP12(p12FilePath: String, password: String, keyStoreAlias: String) {
+    fun importClientCertificateFromP12(p12FilePath: String, password: String, p12Alias: String) {
         try {
-            val p12 = KeyStore.getInstance("pkcs12")
-            p12.load(FileInputStream(p12FilePath), password.toCharArray())
-            val aliases = p12.aliases()
+            val p12Store = KeyStore.getInstance("PKCS12").apply {
+                load(FileInputStream(p12FilePath), password.toCharArray())
+            }
+            val aliases = p12Store.aliases()
             while (aliases.hasMoreElements()) {
                 val alias = aliases.nextElement()
-                if (p12.isCertificateEntry(alias)) {
-                    val certificate = p12.getCertificate(alias)
-                    keyStore.setCertificateEntry(keyStoreAlias, certificate)
+                if (p12Store.isKeyEntry(alias)) {
+                    val key = p12Store.getKey(alias, password.toCharArray())
+                    val certificate = p12Store.getCertificate(alias)
+                    val intermediates = p12Store.getCertificateChain(alias)
+
+                    storeP12Contents(key, certificate, intermediates, password, p12Alias)
 
                     break
                 }
             }
         } catch (e: Exception) {
+            Log.d("MIGUEL EXCEPTION", "IMPORTING")
             throw e
         }
     }
 
-    fun getCertificate(alias: String): Certificate? {
-        if (keyStore.containsAlias(alias)) {
-            return keyStore.getCertificate(alias)
+    fun getClientCertificates(p12Alias: String): Pair<HeldCertificate?, Array<X509Certificate>?> {
+        val password = APIClientModule.retrieveValue(p12Alias)
+        if (password != null) {
+            val p12File = APIClientModule.context.openFileInput(p12Alias)
+            val p12Store = KeyStore.getInstance("PKCS12").apply {
+                load(p12File, password.toCharArray())
+            }
+
+            val keyAlias = getKeyEntryAlias(p12Alias)
+            if (p12Store.containsAlias(keyAlias)) {
+                val certificateAlias = getCertificateEntryAlias(p12Alias)
+
+                val key = p12Store.getKey(keyAlias, null) as PrivateKey
+                val certificate = p12Store.getCertificate(certificateAlias) as X509Certificate
+                val heldCertificate = HeldCertificate(KeyPair(certificate.publicKey, key), certificate)
+
+                val intermediates = p12Store.getCertificateChain(keyAlias)
+                        .map { it as X509Certificate }
+                        .toTypedArray()
+
+                return Pair(heldCertificate, intermediates)
+            } else {
+                Log.d("MIGUEL NO CERTIFICATES", keyAlias)
+            }
         }
 
-        return null
+        return Pair(null, null)
     }
 
-    private fun setAndLoadKeyStore() {
-        keyStore = KeyStore.getInstance(KEY_STORE_TYPE)
-        keyStore.load(null)
+    fun deleteClientCertificates(p12Alias: String) {
+        APIClientModule.context.deleteFile(p12Alias)
     }
 
-    private fun generateSecretKeyPairIfNeeded() {
-        if (getSecretKey() == null) {
+    private fun loadAndroidKeyStore() {
+        androidKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE_TYPE).apply { load(null) }
+    }
+
+    private fun generateAndroidKeyIfNeeded() {
+        if (getAndroidKey() == null) {
             val parameterSpec = KeyGenParameterSpec.Builder(
-                    SECRET_KEY_ALIAS,
+                    ANDROID_KEY_ALIAS,
                     KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
             )
                     .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                    .setRandomizedEncryptionRequired(true)
                     .build()
 
-            keyGenerator.init(parameterSpec)
-            keyGenerator.generateKey()
+            androidKeyGenerator.init(parameterSpec)
+            androidKeyGenerator.generateKey()
         }
     }
 
-    private fun getSecretKey(): SecretKey? {
-        if (!keyStore.containsAlias(SECRET_KEY_ALIAS))
+    private fun getAndroidKey(): SecretKey? {
+        if (!androidKeyStore.containsAlias(ANDROID_KEY_ALIAS))
             return null
 
-        val secretKeyEntry = keyStore.getEntry(SECRET_KEY_ALIAS, null) as KeyStore.SecretKeyEntry
+        val secretKeyEntry = androidKeyStore.getEntry(ANDROID_KEY_ALIAS, null) as KeyStore.SecretKeyEntry
         return secretKeyEntry.secretKey
+    }
+
+    private fun getKeyEntryAlias(aliasPrefix: String): String {
+        return "$aliasPrefix-$P12_KEY_ALIAS"
+    }
+
+    private fun getCertificateEntryAlias(aliasPrefix: String): String {
+        return "$aliasPrefix-$P12_CERTIFICATE_ALIAS"
+    }
+
+    private fun storeP12Contents(key: Key, certificate: Certificate, intermediates: Array<Certificate>, password: String, p12Alias: String) {
+        val p12Store = KeyStore.getInstance("PKCS12").apply {
+            load(null)
+        }
+
+        val keyAlias = getKeyEntryAlias(p12Alias)
+        val certificateAlias = getCertificateEntryAlias(p12Alias)
+        p12Store.setKeyEntry(keyAlias, key, null, intermediates)
+        p12Store.setCertificateEntry(certificateAlias, certificate)
+
+        val p12File = APIClientModule.context.openFileOutput(p12Alias, Context.MODE_PRIVATE)
+        p12Store.store(p12File, password.toCharArray())
+
+        APIClientModule.storeValue(password, p12Alias)
     }
 }

--- a/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/KeyStoreHelper.kt
@@ -61,8 +61,12 @@ object KeyStoreHelper {
             val aliases = p12.aliases()
             while (aliases.hasMoreElements()) {
                 val alias = aliases.nextElement()
-                val certificate = p12.getCertificate(alias)
-                keyStore.setCertificateEntry(keyStoreAlias, certificate)
+                if (p12.isCertificateEntry(alias)) {
+                    val certificate = p12.getCertificate(alias)
+                    keyStore.setCertificateEntry(keyStoreAlias, certificate)
+
+                    break
+                }
             }
         } catch (e: Exception) {
             throw e

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/BearerTokenInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/BearerTokenInterceptor.kt
@@ -5,12 +5,12 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
 
-class BearerTokenInterceptor(private val baseUrl: String, private val bearerAuthTokenResponseHeader: String) : Interceptor {
+class BearerTokenInterceptor(private val alias: String, private val bearerAuthTokenResponseHeader: String) : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         var request = chain.request()
 
-        var token = APIClientModule.retrieveToken(baseUrl)
+        var token = APIClientModule.retrieveValue(alias)
         if (token !== null) {
             request = request.newBuilder()
                     .addHeader("Authorization", "Bearer $token")
@@ -20,7 +20,7 @@ class BearerTokenInterceptor(private val baseUrl: String, private val bearerAuth
         val response = chain.proceed(request)
         token = response.headers[bearerAuthTokenResponseHeader]
         if (token != null) {
-            APIClientModule.storeToken(token, baseUrl)
+            APIClientModule.storeValue(token, alias)
         }
 
         return response

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
       android:allowBackup="false"
       android:theme="@style/AppTheme"
       android:networkSecurityConfig="@xml/network_security_config"
-      android:usesCleartextTraffic="true">
+      android:usesCleartextTraffic="true"
+      android:requestLegacyExternalStorage="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/example/src/components/P12Inputs.tsx
+++ b/example/src/components/P12Inputs.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, { useState } from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { Button, ButtonGroup, Input, Text } from "react-native-elements";
 import DocumentPicker from "react-native-document-picker";
 import { check, request, PERMISSIONS, RESULTS } from "react-native-permissions";
@@ -21,16 +21,22 @@ const P12Inputs = (props: P12InputsProps) => {
     const [url, setUrl] = useState("");
 
     const hasPhotoLibraryPermissions = async () => {
-        let result = await check(PERMISSIONS.IOS.PHOTO_LIBRARY);
+        const permission =
+            Platform.OS === "ios"
+                ? PERMISSIONS.IOS.PHOTO_LIBRARY
+                : PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE;
+        let result = await check(permission);
         if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
             return true;
         } else if (
             result !== RESULTS.BLOCKED &&
             result !== RESULTS.UNAVAILABLE
         ) {
-            await request(PERMISSIONS.IOS.PHOTO_LIBRARY);
+            await request(permission);
             hasPhotoLibraryPermissions();
         }
+
+        console.log(result);
 
         return false;
     };
@@ -73,7 +79,7 @@ const P12Inputs = (props: P12InputsProps) => {
 
     const rightIcon = (
         <View style={{ width: 250 }}>
-            {props.path ? (
+            {Boolean(props.path) ? (
                 <View style={{ flexDirection: "column", height: 50 }}>
                     <View style={{ flexDirection: "row" }}>
                         <View style={{ flex: 1 }}>
@@ -100,34 +106,52 @@ const P12Inputs = (props: P12InputsProps) => {
                     />
                 </View>
             ) : (
-                <View style={{ flexDirection: "column", height: 50 }}>
-                    <Input
-                        placeholder="Download URL"
-                        onChangeText={setUrl}
-                        autoCapitalize="none"
-                        testID="p12_inputs.download_url.input"
-                    />
-                    <ButtonGroup
-                        buttons={buttons.map((button) => button.title)}
-                        onPress={onButtonPress}
-                    />
-                </View>
+                <Input
+                    placeholder="Download URL"
+                    onChangeText={setUrl}
+                    autoCapitalize="none"
+                    testID="p12_inputs.download_url.input"
+                />
             )}
         </View>
     );
 
     return (
-        <Input
-            placeholder={props.title}
-            disabled={true}
-            style={{ fontWeight: "bold", fontSize: 17, opacity: 1 }}
-            containerStyle={{ flex: 1, paddingBottom: 40 }}
-            inputContainerStyle={{
-                borderColor: "rgba(255,255,255,0)",
-            }}
-            rightIcon={rightIcon}
-            labelStyle={{ flex: 12, flexWrap: "wrap", height: 100 }}
-        />
+        <>
+            <Input
+                placeholder={props.title}
+                disabled={true}
+                style={{
+                    fontWeight: "bold",
+                    fontSize: 17,
+                    opacity: 1,
+                }}
+                inputContainerStyle={{
+                    borderColor: "rgba(255,255,255,0)",
+                }}
+                rightIcon={rightIcon}
+                labelStyle={{ flex: 12, flexWrap: "wrap" }}
+            />
+            {Boolean(!props.path) ? (
+                <View
+                    style={{
+                        flex: 1,
+                        alignItems: "flex-end",
+                        marginTop: -30,
+                        paddingRight: 4,
+                        paddingBottom: 10,
+                    }}
+                >
+                    <ButtonGroup
+                        containerStyle={{ width: 200 }}
+                        buttons={buttons.map((button) => button.title)}
+                        onPress={onButtonPress}
+                    />
+                </View>
+            ) : (
+                <View style={{ height: 20 }} />
+            )}
+        </>
     );
 };
 

--- a/src/APIClient/index.tsx
+++ b/src/APIClient/index.tsx
@@ -44,7 +44,7 @@ class APIClient implements APIClientInterface {
     onClientErrorSubscription?: EmitterSubscription;
 
     constructor(baseUrl: string, config: APIClientConfiguration = {}) {
-        this.baseUrl = baseUrl;
+        this.baseUrl = removeTrailingSlashes(baseUrl);
         this.config = Object.assign({}, DEFAULT_API_CLIENT_CONFIG, config);
         validateAPIClientConfiguration(config);
     }
@@ -195,6 +195,10 @@ const isValidBaseURL = (baseUrl: string) => {
         require_valid_protocol: true,
         require_host: true,
     });
+};
+
+const removeTrailingSlashes = (baseUrl: string) => {
+    return baseUrl.replace(/\/+$/, "");
 };
 
 export { getOrCreateAPIClient };


### PR DESCRIPTION
#### Summary

#### Handling of client certificate
Importing of the client certificate is done by:
1. Loading the user provided P12 file as a PKCS12 KeyStore
2. Looping through aliases
3. Grabbing only the first entry that is key entry
4. Loading a new PKCS12 KeyStore
5. Writing the key and certificate entries into this new KeyStore
6. Creating a file using `APIClientModule.context.openFileInput` and storing the KeyStore there using the user provided password
7. Encrypting the password and storing in SharedPreferences

#### Using the client certificate:
1. Retrieve and decrypt the password from SharedPreferences
2. Load our created PKCS12 KeyStore using the password
3. Retrieve the private key, client certificate, and intermediate certificates from the KeyStore and use them to create an OkHttp3 HeldCertificate which is then used to build a HandshakeCertificates
4. Use the HandshakeCertificates to add an SSLSocketFactory to the OkHttpClient

#### Handling trusting of self-signed server certificate
1. Added a `trustSelfSignedServerCertificate` instance property on NetworkClient
2. When this property is set to true:
* `addInsecureHost` for the client's baseUrl.host is added on HandshakeCertificates. This trusts any certificate presented by the server
* `hostnameVerifier` is set on the OkHttpClient to always return true. This means that we will not check that the server's certificate matches on hostname. This is required for our testing since our self-signed certificates are not created for real domains. I've added a note to the README file, but maybe we should consider not skipping hostname verification?

https://mattermost.atlassian.net/browse/MM-30594
https://mattermost.atlassian.net/browse/MM-34376