### PR TITLE
Follow redirects only for GenericClient

### DIFF
--- a/@types/APIClients.ts
+++ b/@types/APIClients.ts
@@ -33,7 +33,7 @@ type ClientResponse = {
     headers?: ClientHeaders;
     data?: Record<string, unknown>;
     code: number;
-    lastRequestedUrl: string;
+    redirectUrls?: Array<string>;
     ok: boolean;
     retriesExhausted?: boolean;
 };

--- a/@types/APIClients.ts
+++ b/@types/APIClients.ts
@@ -87,7 +87,6 @@ type ClientP12Configuration = {
 };
 
 type SessionConfiguration = {
-    followRedirects?: boolean;
     allowsCellularAccess?: boolean;
     waitsForConnectivity?: boolean;
     timeoutIntervalForRequest?: number;

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -21,14 +21,16 @@ fun Response.getRedirectUrls(): WritableArray? {
     if (priorResponse == null)
         return null
 
-    val redirectUrls = Arguments.createArray()
-    redirectUrls.pushString(request.url.toString())
+    val list = mutableListOf(request.url.toString())
 
-    var originalResponse = priorResponse
+    var originalResponse: Response? = priorResponse
     while (originalResponse != null) {
-        redirectUrls.pushString(originalResponse.request.url.toString())
+        list.add(0, originalResponse.request.url.toString())
         originalResponse = originalResponse.priorResponse
     }
+
+    val redirectUrls = Arguments.createArray()
+    list.forEach { redirectUrls.pushString(it) }
 
     return redirectUrls
 }

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -1,6 +1,7 @@
 package com.mattermost.networkclient
 
 import com.facebook.react.bridge.*
+import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
@@ -17,11 +18,8 @@ var Response.retriesExhausted: Boolean? by NetworkClient.RequestRetriesExhausted
  * @return WriteableMap for passing back to App
  */
 fun Response.toWritableMap(): WritableMap {
-    val headersMap = Arguments.createMap();
-    headers.forEach { k -> headersMap.putString(k.first, k.second) }
-
     val map = Arguments.createMap()
-    map.putMap("headers", headersMap)
+    map.putMap("headers", headers.toWritableMap())
     map.putInt("code", code)
     map.putBoolean("ok", isSuccessful)
     map.putString("lastRequestedUrl", request.url.toString())
@@ -56,6 +54,20 @@ fun Request.Builder.applyHeaders(headers: ReadableMap?): Request.Builder {
     }
 
     return this;
+}
+
+/**
+ * Parses Headers into a WritableMap
+ */
+fun Headers.toWritableMap(): WritableMap {
+    val writableMap = Arguments.createMap()
+    var i = 0
+    while (i < size) {
+        writableMap.putString(name(i), value(i))
+        i++
+    }
+
+    return writableMap
 }
 
 /**

--- a/android/src/main/java/com/mattermost/networkclient/GenericClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/GenericClientModule.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.*
 import java.lang.Exception
 
 class GenericClientModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-    private var client = NetworkClient();
+    private var client = NetworkClient()
 
     override fun getName(): String {
         return "GenericClient"

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -114,7 +114,7 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
         val newRequest = request
                 .newBuilder()
                 .applyHeaders(clientHeaders)
-                .build();
+                .build()
 
         return okHttpClient.newCall(newRequest)
     }
@@ -179,8 +179,8 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
     }
 
     private fun applyGenericClientBuilderConfiguration() {
-        builder.followRedirects(true);
-        builder.followSslRedirects(true);
+        builder.followRedirects(true)
+        builder.followSslRedirects(true)
     }
 
     private fun applyClientBuilderConfiguration(options: ReadableMap?, cookieJar: CookieJar?) {
@@ -188,9 +188,9 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
         setClientRetryInterceptor(options)
         setClientTimeoutInterceptor(options)
 
-        builder.followRedirects(false);
-        builder.followSslRedirects(false);
-        builder.retryOnConnectionFailure(false);
+        builder.followRedirects(false)
+        builder.followSslRedirects(false)
+        builder.retryOnConnectionFailure(false)
         builder.addInterceptor(RuntimeInterceptor(this, "retry"))
         builder.addInterceptor(RuntimeInterceptor(this, "timeout"))
 
@@ -215,15 +215,15 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
             val config = options.getMap("sessionConfiguration")!!
 
             if (config.hasKey("httpMaximumConnectionsPerHost")) {
-                val maxConnections = config.getInt("httpMaximumConnectionsPerHost");
+                val maxConnections = config.getInt("httpMaximumConnectionsPerHost")
                 val dispatcher = Dispatcher()
                 dispatcher.maxRequests = maxConnections
                 dispatcher.maxRequestsPerHost = maxConnections
-                builder.dispatcher(dispatcher);
+                builder.dispatcher(dispatcher)
             }
 
             if (config.hasKey("enableCompression")) {
-                builder.minWebSocketMessageToCompress(0);
+                builder.minWebSocketMessageToCompress(0)
             }
         }
     }
@@ -234,11 +234,11 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
                 .applyHeaders(clientHeaders)
                 .applyHeaders(headers)
                 .method(method.toUpperCase(), body)
-                .build();
+                .build()
     }
 
     private fun buildMultipartBody(uri: Uri, fileBody: RequestBody, multipartOptions: ReadableMap): RequestBody {
-        val multipartBody = MultipartBody.Builder();
+        val multipartBody = MultipartBody.Builder()
         multipartBody.setType(MultipartBody.FORM)
 
         var name = "files"
@@ -248,9 +248,9 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
         multipartBody.addFormDataPart(name, uri.lastPathSegment, fileBody)
 
         if (multipartOptions.hasKey("data")) {
-            val multipartData = multipartOptions.getMap("data")!!.toHashMap();
+            val multipartData = multipartOptions.getMap("data")!!.toHashMap()
             for ((k, v) in multipartData) {
-                multipartBody.addFormDataPart(k, v as String);
+                multipartBody.addFormDataPart(k, v as String)
             }
         }
 
@@ -277,7 +277,7 @@ class NetworkClient(private val baseUrl: HttpUrl? = null, private val options: R
 
     private fun getBearerTokenInterceptor(options: ReadableMap?): BearerTokenInterceptor? {
         if (options != null && options.hasKey("requestAdapterConfiguration")) {
-            val requestAdapterConfiguration = options.getMap("requestAdapterConfiguration")!!;
+            val requestAdapterConfiguration = options.getMap("requestAdapterConfiguration")!!
             if (requestAdapterConfiguration.hasKey("bearerAuthTokenResponseHeader")) {
                 val bearerAuthTokenResponseHeader = requestAdapterConfiguration.getString("bearerAuthTokenResponseHeader")!!
                 return BearerTokenInterceptor(TOKEN_ALIAS, bearerAuthTokenResponseHeader)

--- a/example/detox/e2e/support/ui/component/response_success_overlay.js
+++ b/example/detox/e2e/support/ui/component/response_success_overlay.js
@@ -8,8 +8,8 @@ class ResponseSuccessOverlay {
         responseSuccessDataText: "response_success_overlay.success.data.text",
         responseSuccessHeadersText:
             "response_success_overlay.success.headers.text",
-        responseSuccessLastRequestedUrlText:
-            "response_success_overlay.success.last_requested_url.text",
+        responseSuccessRedirectUrlsText:
+            "response_success_overlay.success.redirect_urls.text",
         responseSuccessOkText: "response_success_overlay.success.ok.text",
         responseSuccessRetriesExhaustedText:
             "response_success_overlay.success.retries_exhausted.text",
@@ -26,8 +26,8 @@ class ResponseSuccessOverlay {
     responseSuccessHeadersText = element(
         by.id(this.testID.responseSuccessHeadersText)
     );
-    responseSuccessLastRequestedUrlText = element(
-        by.id(this.testID.responseSuccessLastRequestedUrlText)
+    responseSuccessRedirectUrlsText = element(
+        by.id(this.testID.responseSuccessRedirectUrlsText)
     );
     responseSuccessOkText = element(by.id(this.testID.responseSuccessOkText));
     responseSuccessRetriesExhaustedText = element(

--- a/example/detox/e2e/support/ui/screen/create_api_client.js
+++ b/example/detox/e2e/support/ui/screen/create_api_client.js
@@ -54,13 +54,6 @@ class CreateApiClientScreen {
     cancelRequestsOn401CheckboxTrue = element(
         by.text("Cancel Requests On 401? [true]")
     );
-    followRedirectsCheckboxFalse = element(
-        by.text("Follow Redirects? [false]")
-    );
-    followRedirectsCheckboxTrue = element(by.text("Follow Redirects? [true]"));
-    trustSelfSignedServerCertificateCheckboxFalse = element(
-        by.text("Trust Self-Signed Server Certificate? [false]")
-    );
     trustSelfSignedServerCertificateCheckboxTrue = element(
         by.text("Trust Self-Signed Server Certificate? [true]")
     );
@@ -253,24 +246,6 @@ class CreateApiClientScreen {
         );
         await this.cancelRequestsOn401CheckboxFalse.tap();
         await expect(this.cancelRequestsOn401CheckboxTrue).toBeVisible();
-    };
-
-    toggleOffFollowRedirectsCheckbox = async () => {
-        await waitForAndScrollDown(
-            this.followRedirectsCheckboxTrue,
-            this.testID.createApiClientScrollView
-        );
-        await this.followRedirectsCheckboxTrue.tap();
-        await expect(this.followRedirectsCheckboxFalse).toBeVisible();
-    };
-
-    toggleOnFollowRedirectsCheckbox = async () => {
-        await waitForAndScrollDown(
-            this.followRedirectsCheckboxFalse,
-            this.testID.createApiClientScrollView
-        );
-        await this.followRedirectsCheckboxFalse.tap();
-        await expect(this.followRedirectsCheckboxTrue).toBeVisible();
     };
 
     toggleOffTrustSelfSignedServerCertificateCheckbox = async () => {

--- a/example/detox/e2e/test/helpers.js
+++ b/example/detox/e2e/test/helpers.js
@@ -390,17 +390,17 @@ export const verifyResponseSuccessOverlay = async (
         responseSuccessCodeText,
         responseSuccessDataText,
         responseSuccessHeadersText,
-        responseSuccessLastRequestedUrlText,
+        responseSuccessRedirectUrlsText,
         responseSuccessOkText,
         responseSuccessRetriesExhaustedText,
     } = ResponseSuccessOverlay;
 
     // * Verify request URL, response code, response status, and retries exhausted
-    await waitFor(responseSuccessLastRequestedUrlText)
+    await waitFor(responseSuccessRedirectUrlsText)
         .toBeVisible()
         .withTimeout(timeouts.TEN_SEC);
     const endTime = Date.now();
-    await expect(responseSuccessLastRequestedUrlText).toHaveText(url);
+    await expect(responseSuccessRedirectUrlsText).toHaveText(url);
     await expect(responseSuccessCodeText).toHaveText(status.toString());
     await expect(responseSuccessOkText).toHaveText(
         status === 200 ? "true" : "false"

--- a/example/src/components/ResponseSuccessOverlay.tsx
+++ b/example/src/components/ResponseSuccessOverlay.tsx
@@ -27,9 +27,9 @@ const ResponseSuccessOverlay = ({
         >
             <>
                 <Button title="Close" onPress={hide} />
-                <Text h4>URL</Text>
-                <Text testID="response_success_overlay.success.last_requested_url.text">
-                    {response?.lastRequestedUrl}
+                <Text h4>OK</Text>
+                <Text testID="response_success_overlay.success.ok.text">
+                    {response?.ok.toString()}
                 </Text>
                 <Divider />
                 <Text h4>Code</Text>
@@ -37,11 +37,15 @@ const ResponseSuccessOverlay = ({
                     {response?.code}
                 </Text>
                 <Divider />
-                <Text h4>OK</Text>
-                <Text testID="response_success_overlay.success.ok.text">
-                    {response?.ok.toString()}
-                </Text>
-                <Divider />
+                {Boolean(response?.redirectUrls?.length) && (
+                    <>
+                        <Text h4>Redirect URLs</Text>
+                        <Text testID="response_success_overlay.success.redirect_urls.text">
+                            {response!.redirectUrls!.join(", ")}
+                        </Text>
+                        <Divider />
+                    </>
+                )}
                 <Text h4>Retries Exhausted?</Text>
                 <Text testID="response_success_overlay.success.retries_exhausted.text">
                     {response?.hasOwnProperty("retriesExhausted")

--- a/example/src/hooks/index.tsx
+++ b/example/src/hooks/index.tsx
@@ -9,7 +9,6 @@ type UseSessionConfigurationResponse = [
     () => void,
     () => void,
     () => void,
-    () => void,
     (timeoutIntervalForRequest: number) => void,
     (timeoutIntervalForResource: number) => void,
     (httpMaximumConnectionsPerHost: number) => void
@@ -20,7 +19,6 @@ export const useSessionConfiguration = (): UseSessionConfigurationResponse => {
         sessionConfiguration,
         setSessionConfiguration,
     ] = useState<SessionConfiguration>({
-        followRedirects: true,
         allowsCellularAccess: true,
         waitsForConnectivity: false,
         timeoutIntervalForRequest: 30000,
@@ -30,11 +28,6 @@ export const useSessionConfiguration = (): UseSessionConfigurationResponse => {
         trustSelfSignedServerCertificate: false,
     });
 
-    const toggleFollowRedirects = () =>
-        setSessionConfiguration({
-            ...sessionConfiguration,
-            followRedirects: !sessionConfiguration.followRedirects,
-        });
     const toggleAllowsCellularAccess = () =>
         setSessionConfiguration({
             ...sessionConfiguration,
@@ -77,7 +70,6 @@ export const useSessionConfiguration = (): UseSessionConfigurationResponse => {
 
     return [
         sessionConfiguration,
-        toggleFollowRedirects,
         toggleAllowsCellularAccess,
         toggleWaitsForConnectivity,
         toggleCancelRequestsOnUnauthorized,

--- a/example/src/screens/CreateAPIClientScreen.tsx
+++ b/example/src/screens/CreateAPIClientScreen.tsx
@@ -35,7 +35,6 @@ export default function CreateAPIClientScreen({
 
     const [
         sessionConfiguration,
-        toggleFollowRedirects,
         toggleAllowsCellularAccess,
         toggleWaitsForConnectivity,
         toggleCancelRequestsOnUnauthorized,
@@ -203,17 +202,6 @@ export default function CreateAPIClientScreen({
                     title={`Alert on client error? [${alertOnClientError}]`}
                     checked={alertOnClientError}
                     onPress={toggleAlertOnClientError}
-                    iconType="ionicon"
-                    checkedIcon="ios-checkmark-circle"
-                    uncheckedIcon="ios-checkmark-circle"
-                    iconRight
-                    textStyle={styles.checkboxText}
-                />
-
-                <CheckBox
-                    title={`Follow Redirects? [${sessionConfiguration.followRedirects}]`}
-                    checked={sessionConfiguration.followRedirects as boolean}
-                    onPress={toggleFollowRedirects}
                     iconType="ionicon"
                     checkedIcon="ios-checkmark-circle"
                     uncheckedIcon="ios-checkmark-circle"

--- a/example/src/utils/index.tsx
+++ b/example/src/utils/index.tsx
@@ -58,7 +58,6 @@ const buildDefaultApiClientConfiguration = (
     }
 ): APIClientConfiguration => {
     const sessionConfiguration = {
-        followRedirects: true,
         allowsCellularAccess: true,
         waitsForConnectivity: false,
         timeoutIntervalForRequest: 30000,

--- a/ios/APIClient.swift
+++ b/ios/APIClient.swift
@@ -119,7 +119,7 @@ class APIClient: RCTEventEmitter, NetworkClient {
         if options != JSON.null {
             let configuration = getURLSessionConfiguration(from: options)
             let interceptor = getSessionInterceptor(from: options)
-            let redirectHandler = getRedirectHandler(from: options)
+            let redirectHandler = Redirector(behavior: .doNotFollow)
             let retryPolicy = getRetryPolicy(from: options)
             let cancelRequestsOnUnauthorized = options["sessionConfiguration"]["cancelRequestsOnUnauthorized"].boolValue
             let bearerAuthTokenResponseHeader = options["requestAdapterConfiguration"]["bearerAuthTokenResponseHeader"].string
@@ -414,14 +414,6 @@ class APIClient: RCTEventEmitter, NetworkClient {
         }
 
         return config
-    }
-
-    func getRedirectHandler(from options: JSON) -> RedirectHandler? {
-        if options["followRedirects"].exists() {
-            return Redirector(behavior: options["followRedirects"].boolValue ? .follow : .doNotFollow)
-        }
-
-        return nil
     }
     
     func rejectInvalidSession(for baseUrl: URL, withRejecter reject: @escaping RCTPromiseRejectBlock) -> Void {

--- a/ios/GenericClient.swift
+++ b/ios/GenericClient.swift
@@ -12,7 +12,7 @@ import SwiftyJSON
 
 @objc(GenericClient)
 class GenericClient: NSObject, NetworkClient {
-    var session = AF
+    var session = Session(redirectHandler: Redirector(behavior: .follow))
 
     @objc(get:withOptions:withResolver:withRejecter:)
     func get(url: String, options: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {

--- a/src/APIClient/index.tsx
+++ b/src/APIClient/index.tsx
@@ -22,7 +22,6 @@ const CLIENTS: { [key: string]: APIClient } = {};
 
 const DEFAULT_API_CLIENT_CONFIG: APIClientConfiguration = {
     sessionConfiguration: {
-        followRedirects: true,
         allowsCellularAccess: true,
         waitsForConnectivity: false,
         timeoutIntervalForRequest: 30,

--- a/src/schemas.tsx
+++ b/src/schemas.tsx
@@ -8,7 +8,6 @@ const { APIClient: NativeAPIClient } = NativeModules;
 const { RETRY_TYPES } = NativeAPIClient.getConstants();
 
 const SessionConfigurationSchema = z.object({
-    followRedirects: z.boolean().optional(),
     allowsCellularAccess: z.boolean().optional(),
     waitsForConnectivity: z.boolean().optional(),
     timeoutIntervalForRequest: z.number().optional(),


### PR DESCRIPTION
#### Summary
* GenericClient requests will follow all redirects and return a list of redirect URLs via `response.redirectUrls`
* APIClient requests will not follow redirects

GenericClient request (Android and iOS):
![Simulator Screen Shot - iPhone 11 - 2021-05-11 at 19 42 27](https://user-images.githubusercontent.com/3208014/117912217-f8db7280-b293-11eb-8875-35692326910f.png)

![Screenshot_1620788257](https://user-images.githubusercontent.com/3208014/117912255-08f35200-b294-11eb-8cb7-0aceefd3fde2.png)

APIClient request (Android and iOS):
![Simulator Screen Shot - iPhone 11 - 2021-05-11 at 19 43 10](https://user-images.githubusercontent.com/3208014/117912276-10b2f680-b294-11eb-91bd-c106f3dd042d.png)

![Screenshot_1620788291](https://user-images.githubusercontent.com/3208014/117912288-16a8d780-b294-11eb-81eb-6826414a30b7.png)

