### PR TITLE
Fix issues found while integrating into mattermost-mobile

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -126,7 +126,7 @@ internal class NetworkClient(private val baseUrl: HttpUrl? = null, private val o
     }
 
     fun cleanUpAfter(response: Response) {
-        requestRetriesExhausted.remove(response.request)
+        requestRetriesExhausted.remove(response)
         requestRetryInterceptors.remove(response.request)
         requestTimeoutInterceptors.remove(response.request)
     }

--- a/ios/APIClient.swift
+++ b/ios/APIClient.swift
@@ -254,7 +254,12 @@ class APIClient: RCTEventEmitter, NetworkClient {
             return
         }
 
-        let url = baseUrl.appendingPathComponent(endpoint)
+        let urlString = "\(baseUrl.absoluteString)\(endpoint)"
+        guard let url = URL(string: urlString) else {
+            rejectMalformed(url: urlString, withRejecter: reject)
+            return
+        }
+
         upload(fileUrl, to: url, forSession: session, withTaskId: taskId, withOptions: JSON(options), withResolver: resolve, withRejecter: reject)
     }
     
@@ -362,7 +367,12 @@ class APIClient: RCTEventEmitter, NetworkClient {
             return
         }
 
-        let url = baseUrl.appendingPathComponent(endpoint)
+        let urlString = "\(baseUrl.absoluteString)\(endpoint)"
+        guard let url = URL(string: urlString) else {
+            rejectMalformed(url: urlString, withRejecter: reject)
+            return
+        }
+
         handleRequest(for: url, withMethod: method, withSession: session, withOptions: options, withResolver: resolve, withRejecter: reject)
     }
 


### PR DESCRIPTION
#### Summary
* Cannot use `appendingPathComponent` since the `endpoint` value might contain a query string; Instead just concatenate the baseUrl with the endpoint
* `requestRetriesExhausted` is a HashMap with `response` keys, not `request`
