### PR TITLE
fix: android generic & api clients

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/APIClientModule.kt
@@ -169,34 +169,34 @@ internal class APIClientModule(reactContext: ReactApplicationContext) : ReactCon
         try {
             clients[url]!!.invalidate()
             clients.remove(url);
-            promise.resolve(clients.keys);
+            promise.resolve(null);
         } catch (error: Exception) {
             promise.reject(error)
         }
     }
 
     @ReactMethod
-    fun get(baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    fun get(baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         request("GET", baseUrl, endpoint, options, promise)
     }
 
     @ReactMethod
-    fun post(baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    fun post(baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         request("POST", baseUrl, endpoint, options, promise)
     }
 
     @ReactMethod
-    fun put(baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    fun put(baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         request("PUT", baseUrl, endpoint, options, promise)
     }
 
     @ReactMethod
-    fun patch(baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    fun patch(baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         request("PATCH", baseUrl, endpoint, options, promise)
     }
 
     @ReactMethod
-    fun delete(baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    fun delete(baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         request("DELETE", baseUrl, endpoint, options, promise)
     }
 
@@ -246,7 +246,7 @@ internal class APIClientModule(reactContext: ReactApplicationContext) : ReactCon
         return constants
     }
 
-    private fun request(method: String, baseUrl: String, endpoint: String, options: ReadableMap, promise: Promise) {
+    private fun request(method: String, baseUrl: String, endpoint: String, options: ReadableMap?, promise: Promise) {
         try {
             val url = baseUrl.toHttpUrl()
             val client = clients[url]!!

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -46,11 +46,12 @@ fun Response.toWritableMap(): WritableMap {
     map.putBoolean("ok", isSuccessful)
 
     if (body !== null) {
+        val bodyString = body!!.string()
         try {
-            val data = JSONObject(body!!.string()).toWritableMap()
+            val data = JSONObject(bodyString).toWritableMap()
             map.putMap("data", data)
         } catch (_: Exception) {
-            map.putString("data", body!!.string())
+            map.putString("data", bodyString)
         }
     }
 

--- a/android/src/main/java/com/mattermost/networkclient/GenericClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/GenericClientModule.kt
@@ -11,36 +11,36 @@ internal class GenericClientModule(reactContext: ReactApplicationContext) : Reac
     }
 
     @ReactMethod
-    fun head(url: String, options: ReadableMap, promise: Promise) {
+    fun head(url: String, options: ReadableMap?, promise: Promise) {
         request("HEAD", url, options, promise)
     }
 
     @ReactMethod
-    fun get(url: String, options: ReadableMap, promise: Promise) {
+    fun get(url: String, options: ReadableMap?, promise: Promise) {
         request("GET", url, options, promise)
     }
 
     @ReactMethod
-    fun post(url: String, options: ReadableMap, promise: Promise) {
+    fun post(url: String, options: ReadableMap?, promise: Promise) {
         request("POST", url, options, promise)
     }
 
     @ReactMethod
-    fun put(url: String, options: ReadableMap, promise: Promise) {
+    fun put(url: String, options: ReadableMap?, promise: Promise) {
         request("PUT", url, options, promise)
     }
 
     @ReactMethod
-    fun patch(url: String, options: ReadableMap, promise: Promise) {
+    fun patch(url: String, options: ReadableMap?, promise: Promise) {
         request("PATCH", url, options, promise)
     }
 
     @ReactMethod
-    fun delete(url: String, options: ReadableMap, promise: Promise) {
+    fun delete(url: String, options: ReadableMap?, promise: Promise) {
         request("DELETE", url, options, promise)
     }
 
-    private fun request(method: String, url: String, options: ReadableMap, promise: Promise) {
+    private fun request(method: String, url: String, options: ReadableMap?, promise: Promise) {
         try {
             client.request(method, url, options).use { response ->
                 promise.resolve(response.toWritableMap())

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -273,9 +273,7 @@ internal class NetworkClient(private val baseUrl: HttpUrl? = null, private val o
         }
 
         return baseUrl
-                .newBuilder()
-                .addPathSegments(endpoint.trim { c -> c == '/' })
-                .build()
+                .newBuilder(endpoint)?.build()
                 .toString()
     }
 
@@ -470,7 +468,7 @@ internal class NetworkClient(private val baseUrl: HttpUrl? = null, private val o
 
         val domain = baseUrl.toString()
         val cookieManager = CookieManager.getInstance()
-        val cookieString = cookieManager.getCookie(domain)
+        val cookieString = cookieManager.getCookie(domain) ?: return
         val cookies = cookieString.split(";").toTypedArray()
         for (i in cookies.indices) {
             val cookieParts = cookies[i].split("=").toTypedArray()


### PR DESCRIPTION
#### Summary
* Android Generic client to have options set as optional
* Android invalidate to check if cookieString is not null
* Android Request Builder to correctly build the endpoint including queryStrings