### PR TITLE
fix: android authorization header interceptor

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/interceptors/BearerTokenInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/BearerTokenInterceptor.kt
@@ -13,7 +13,7 @@ class BearerTokenInterceptor(private val alias: String, private val bearerAuthTo
         var token = APIClientModule.retrieveValue(alias)
         if (token !== null) {
             request = request.newBuilder()
-                    .addHeader("Authorization", "Bearer $token")
+                    .header("Authorization", "Bearer $token")
                     .build()
         }
 


### PR DESCRIPTION
#### Summary
Add or Replace Auth header instead of always attempting to add it

