### PR TITLE
Remove use of kSecAttrLabel with token

### DIFF
--- a/ios/Keychain.swift
+++ b/ios/Keychain.swift
@@ -93,6 +93,7 @@ class Keychain {
         
         var attributes = try buildTokenAttributes(for: serverUrl)
         attributes[kSecValueData] = tokenData
+        attributes[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 
         let status: OSStatus = SecItemAdd(attributes as CFDictionary, nil)
         if status == errSecDuplicateItem {
@@ -190,8 +191,7 @@ class Keychain {
         
         var attributes: [CFString: Any] = [
             kSecClass: kSecClassInternetPassword,
-            kSecAttrServer: serverUrlData,
-            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            kSecAttrServer: serverUrlData
         ]
 
         if let accessGroup = Bundle.main.object(forInfoDictionaryKey: "AppGroupIdentifier") as! String? {

--- a/ios/Keychain.swift
+++ b/ios/Keychain.swift
@@ -190,7 +190,6 @@ class Keychain {
         
         var attributes: [CFString: Any] = [
             kSecClass: kSecClassInternetPassword,
-            kSecAttrLabel: "token",
             kSecAttrServer: serverUrlData,
             kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]


### PR DESCRIPTION
Storing the token with `kSecAttrLabel` was working, however, retrieval was failing. While the [iOS documentation](https://developer.apple.com/documentation/security/ksecclassinternetpassword/) states that it is an applicable attribute, I'm wondering if it's applicable only to Keychain insertions and not retrieval queries? In any case, RNKeychain does not use the `kSecAttrLabel` when storing items of type `kSecClassInternetPassword` so I've removed it. The attribute `kSecAttrAccessible` is also now added in the `setToken` function.