### PR TITLE
fix: force unwrap on UploadRequestBody.kt and ApiClient.swift

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/helpers/UploadRequestBody.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/UploadRequestBody.kt
@@ -20,7 +20,7 @@ class UploadFileRequestBody(private val uri: Uri, private val skipBytes: Long, p
     }
 
     override fun contentType(): MediaType? {
-        return APIClientModule.context.contentResolver.getType(uri)!!.toMediaTypeOrNull();
+        return APIClientModule.context.contentResolver.getType(uri)?.toMediaTypeOrNull();
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
#### Summary
We are using this library on the Mattermost mobile app and we noticed a crash happening on both iOS and Android when performing image uploads.

The cause of the crash was due to some optional values being force-unwrapped and thus causing a Null Pointer exception.

This PR fixes this issue on both platforms.
