### PR TITLE
feat: clear request cache on client invalidate

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -244,6 +244,7 @@ internal class NetworkClient(private val baseUrl: HttpUrl? = null, options: Read
 
     fun invalidate() {
         cancelAllRequests()
+        clearCache()
         clearCookies()
         APIClientModule.deleteValue(TOKEN_ALIAS)
         APIClientModule.deleteValue(P12_ALIAS)
@@ -524,6 +525,21 @@ internal class NetworkClient(private val baseUrl: HttpUrl? = null, options: Read
 
     private fun cancelAllRequests() {
         okHttpClient.dispatcher.cancelAll()
+    }
+
+    private fun clearCache() {
+        if (baseUrl == null)
+            return
+
+        val domain = baseUrl.toString()
+        if (okHttpClient.cache != null) {
+            val urlIterator = okHttpClient.cache!!.urls()
+            while (urlIterator.hasNext()) {
+                if (urlIterator.next().startsWith(domain)) {
+                    urlIterator.remove()
+                }
+            }
+        }
     }
 
     private fun clearCookies() {

--- a/ios/SessionManager.swift
+++ b/ios/SessionManager.swift
@@ -144,6 +144,7 @@ public class SessionManager: NSObject {
             session.session.reset {
                 do {
                     try Keychain.deleteAll(for: baseUrl.absoluteString)
+                    URLCache.shared.removeAllCachedResponses()
                 } catch {
                     NotificationCenter.default.post(name: Notification.Name(API_CLIENT_EVENTS["CLIENT_ERROR"]!),
                                                     object: nil,


### PR DESCRIPTION
#### Summary
On client invalidate remove the entries from the cache.

on Android: if there are any cache entries that match the domain, we remove them all when the client is invalidated.
on iOS: There is no easy way to remove only entries that match a specific domain, we can only retrieve entries for a specific URLRequest or Task, so on client invalidate we are removing all cache responses.
