### PR TITLE
Fix not properly closing the websocket when starting airplane mode

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/WebSocketEventListener.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketEventListener.kt
@@ -10,6 +10,7 @@ import okhttp3.WebSocketListener
 import okio.EOFException
 import org.json.JSONObject
 import java.net.ConnectException
+import java.net.SocketException
 import java.net.URI
 
 class WebSocketEventListener(private val uri: URI) : WebSocketListener() {
@@ -41,7 +42,7 @@ class WebSocketEventListener(private val uri: URI) : WebSocketListener() {
     }
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-        if (t is EOFException || t is ConnectException) {
+        if (t is EOFException || t is ConnectException || t is SocketException) {
             webSocket.close(1001, "connection terminated")
             onClosed(webSocket, 1001, t.localizedMessage ?: "connection terminated")
             return

--- a/ios/WebSocketClient.swift
+++ b/ios/WebSocketClient.swift
@@ -203,7 +203,7 @@ class WebSocketClient: RCTEventEmitter, WebSocketDelegate {
             if hasListeners {
                 let nsError = error as NSError?
                 let errorCode = nsError?.code
-                if (errorCode == 61 && (errorCounter[url] ?? 0) % 2 == 0) {
+                if ((errorCode == 61 || errorCode == 57) && (errorCounter[url] ?? 0) % 2 == 0) {
                     let count = errorCounter[url] ?? 0
                     errorCounter[url] = count + 1
                     self.sendEvent(withName: WEBSOCKET_CLIENT_EVENTS["READY_STATE_EVENT"], body: ["url": url, "message": READY_STATE["CLOSED"]!])


### PR DESCRIPTION
#### Summary
Some of the changes here are speculative, but after testing they seem to work just fine.

On the android side, the main problem is that we were receiving a `SocketException` instead of the other exceptions we were checking for. After a quick look, it seems safe to consider any error here probably is enough to close the connection. https://docs.oracle.com/javase/7/docs/api/java/net/SocketException.html

On the iphone side, the error is a bit more criptic, since it says not much more than error 57. After a big of googling, it seems to be the "websocket not connected" error, which also seems enough to close the websocket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48802
