### PR TITLE
Reject promise if we try to create a ws client when we already have one

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/WebSocketClientModule.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketClientModule.kt
@@ -53,6 +53,10 @@ internal class WebSocketClientModule(reactContext: ReactApplicationContext) : Re
             return promise.reject(error)
         }
 
+        if (clients.containsKey(wsUri)) {
+            return promise.reject("already existing client for this websocket url");
+        }
+
         try {
             clients[wsUri] = NetworkClient(wsUri, baseUrl, options)
             promise.resolve(null)

--- a/ios/WebSocketClient.swift
+++ b/ios/WebSocketClient.swift
@@ -75,6 +75,11 @@ class WebSocketClient: RCTEventEmitter, WebSocketDelegate {
             return
         }
 
+        guard WebSocketManager.default.getWebSocket(for: url) == nil else {
+            rejectAlreadyExisting(withRejecter: reject);
+            return
+        }
+
         do {
             try resolve(WebSocketManager.default.createWebSocket(for: url, withOptions: options, withDelegate: self))
         } catch {
@@ -154,6 +159,12 @@ class WebSocketClient: RCTEventEmitter, WebSocketDelegate {
         reject("\(error.code)", message, error)
     }
     
+    func rejectAlreadyExisting(withRejecter: reject: RCTPromiseRejectBlock) -> Void {
+        let message = "already existing client for this websocket url"
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSKeyValueValidationError, userInfo: [NSLocalizedDescriptionKey: message])
+        reject("\(error.code)", message, error)
+    }
+
     @objc(errorHandler:)
     func errorHandler(notification: Notification) {
         self.sendErrorEvent(for: notification.userInfo!["url"] as! String,

--- a/ios/WebSocketClient.swift
+++ b/ios/WebSocketClient.swift
@@ -159,7 +159,7 @@ class WebSocketClient: RCTEventEmitter, WebSocketDelegate {
         reject("\(error.code)", message, error)
     }
     
-    func rejectAlreadyExisting(withRejecter: reject: RCTPromiseRejectBlock) -> Void {
+    func rejectAlreadyExisting(withRejecter reject: RCTPromiseRejectBlock) -> Void {
         let message = "already existing client for this websocket url"
         let error = NSError(domain: NSCocoaErrorDomain, code: NSKeyValueValidationError, userInfo: [NSLocalizedDescriptionKey: message])
         reject("\(error.code)", message, error)


### PR DESCRIPTION
#### Summary
If we try to create a second websocket client too fast, there may be a race condition on the js side. By rejecting here, we avoid these issues.

#### Ticket Link
Related to: https://github.com/mattermost/mattermost-mobile/pull/7185

