### PR TITLE
feat: emit event when server certificate is not trusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ For both API client and WebSocket client, the following error codes apply:
   | Code | Reason                                                   |
   | ---- | -------------------------------------------------------- |
   | -200 | SSL handshake failed due to a missing client certificate |
+  | -299 | Server SSL certificate is not trusted or invalid         |
 
 ## Method Swizzling
 


### PR DESCRIPTION
#### Summary
When the server certificate (SSL) is not trusted or invalid we now emit an event so that the app can show an error message

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54285
