### PR TITLE
SSL Pinning support

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/ApiClientModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/networkclient/ApiClientModuleImpl.kt
@@ -25,7 +25,7 @@ class ApiClientModuleImpl(reactApplicationContext: ReactApplicationContext) {
     companion object {
         const val NAME = "ApiClient"
 
-        internal lateinit var context: ReactApplicationContext
+        public lateinit var context: ReactApplicationContext
         private val clients = mutableMapOf<HttpUrl, NetworkClient>()
         private val calls = mutableMapOf<String, Call>()
         private lateinit var sharedPreferences: SharedPreferences

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -2,6 +2,7 @@ package com.mattermost.networkclient
 
 import android.annotation.SuppressLint
 import android.net.Uri
+import android.util.Base64
 import android.webkit.CookieManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -22,15 +23,17 @@ import okhttp3.tls.HandshakeCertificates
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
+import java.io.InputStream
 import java.net.URI
+import java.security.MessageDigest
 import java.security.SecureRandom
 import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.Locale
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
-import kotlin.collections.HashMap
 import kotlin.reflect.KProperty
 
 internal class NetworkClient(private val context: ReactApplicationContext, private val baseUrl: HttpUrl? = null, options: ReadableMap? = null, cookieJar: CookieJar? = null) {
@@ -73,6 +76,18 @@ internal class NetworkClient(private val context: ReactApplicationContext, priva
             applyGenericClientBuilderConfiguration()
         } else {
             applyClientBuilderConfiguration(options, cookieJar)
+        }
+
+        val fingerprintsMap = getCertificatesFingerPrints()
+        if (fingerprintsMap.isNotEmpty()) {
+            val pinner = CertificatePinner.Builder()
+            for ((domain, fingerprints) in fingerprintsMap) {
+                for (fingerprint in fingerprints) {
+                    pinner.add(domain, "sha256/$fingerprint")
+                }
+            }
+            val certificatePinner = pinner.build()
+            builder.certificatePinner(certificatePinner)
         }
 
         okHttpClient = builder.build()
@@ -186,6 +201,12 @@ internal class NetworkClient(private val context: ReactApplicationContext, priva
         val call = okHttpClient.newCall(request)
         call.enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
+                if (e is javax.net.ssl.SSLPeerUnverifiedException) {
+                    cancelAllRequests()
+                    emitInvalidPinnedCertificateError()
+                    promise.reject(Exception("Server trust evaluation failed due to reason: Certificate pinning failed for host ${request.url.host}"))
+                    return
+                }
                 promise.reject(e)
             }
 
@@ -457,6 +478,14 @@ internal class NetworkClient(private val context: ReactApplicationContext, priva
         ApiClientModuleImpl.sendJSEvent(ApiClientEvents.CLIENT_ERROR.event, data)
     }
 
+    internal fun emitInvalidPinnedCertificateError() {
+        val data = Arguments.createMap()
+        data.putString("serverUrl", baseUrlString)
+        data.putInt("errorCode", -298)
+        data.putString("errorDescription", "Server trust evaluation failed due to reason: Certificate pinning failed for host ${URI(baseUrlString).host}")
+        ApiClientModuleImpl.sendJSEvent(ApiClientEvents.CLIENT_ERROR.event, data)
+    }
+
     private fun buildHandshakeCertificates(options: ReadableMap?): HandshakeCertificates? {
         if (options != null) {
             // `trustSelfSignedServerCertificate` can be in `options.sessionConfiguration` for
@@ -676,5 +705,37 @@ internal class NetworkClient(private val context: ReactApplicationContext, priva
             val cookieParts = cookies[i].split("=").toTypedArray()
             cookieManager.setCookie(domain, cookieParts[0].trim { it <= ' ' } + "=; Expires=Thurs, 1 Jan 1970 12:00:00 GMT")
         }
+    }
+
+    private fun getCertificateFingerPrint(certInputStream: InputStream): String {
+        val certFactory = CertificateFactory.getInstance("X.509")
+        val certificate = certFactory.generateCertificate(certInputStream) as X509Certificate
+        val sha256 = MessageDigest.getInstance("SHA-256")
+        val fingerprintBytes = sha256.digest(certificate.publicKey.encoded)
+        return Base64.encodeToString(fingerprintBytes, Base64.NO_WRAP)
+    }
+
+    private fun getCertificatesFingerPrints(): Map<String, List<String>> {
+        val fingerprintsMap = mutableMapOf<String, MutableList<String>>()
+        val assetsManager = context.assets
+        val certFiles = assetsManager.list("certs")?.filter { it.endsWith(".cer") || it.endsWith(".crt") } ?: return emptyMap()
+
+        for (fileName in certFiles) {
+            val domain = fileName.substringBeforeLast(".")
+            if (baseUrl != null && baseUrl.host != domain) {
+                continue
+            }
+            val certInputStream = assetsManager.open("certs/$fileName")
+            certInputStream.use {
+                val fingerprint = getCertificateFingerPrint(it)
+                if (fingerprintsMap.containsKey(domain)) {
+                    fingerprintsMap[domain]?.add(fingerprint)
+                } else {
+                    fingerprintsMap[domain] = mutableListOf(fingerprint)
+                }
+            }
+        }
+
+        return fingerprintsMap
     }
 }

--- a/android/src/main/java/com/mattermost/networkclient/enums/APIClientEvents.kt
+++ b/android/src/main/java/com/mattermost/networkclient/enums/APIClientEvents.kt
@@ -5,3 +5,7 @@ enum class ApiClientEvents(val event: String) {
     UPLOAD_PROGRESS("ApiClient-UploadProgress"),
     CLIENT_ERROR("ApiClient-Error"),
 }
+
+enum class SslErrors(val event: Int) {
+    SERVER_TRUST_EVALUATION_FAILED(-298)
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -977,7 +977,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-network-client (1.5.1):
+  - react-native-network-client (1.6.0):
     - Alamofire (~> 5.9.1)
     - DoubleConversion
     - glog
@@ -1707,7 +1707,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
   react-native-document-picker: 9ad9b2bd3a5fd478e86314152f7592a1facc7a91
   react-native-image-picker: f5e7af75efb813aa7239e94310167d2b69b606d6
-  react-native-network-client: 81bb55fac84426ecf328322e03ca187cc9c6f469
+  react-native-network-client: da6ec94fb7099597087c8e7c5519327913af59c7
   react-native-safe-area-context: 7f54ad0a774de306ab790c70d9d950321e5c5449
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
   React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f

--- a/ios/Adapters/BearerAuthenticationAdapter.swift
+++ b/ios/Adapters/BearerAuthenticationAdapter.swift
@@ -18,12 +18,13 @@ import Alamofire
     }
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        if let baseUrl = session.baseUrl {
-            let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest, withSessionBaseUrlString: baseUrl.absoluteString)
-            
-            completion(.success(urlRequest))
-        } else {
+        guard let baseUrl = session.baseUrl else {
             completion(.failure(BaseURLError.missingBaseURL))
+            return
         }
+        
+        let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest, withSessionBaseUrlString: baseUrl.absoluteString)
+        
+        completion(.success(urlRequest))
     }
 }

--- a/ios/Adapters/BearerAuthenticationAdapter.swift
+++ b/ios/Adapters/BearerAuthenticationAdapter.swift
@@ -9,7 +9,7 @@ import Alamofire
                 urlRequest.headers.add(.authorization(bearerToken: bearerToken))
             }
         } catch {
-            NotificationCenter.default.post(name: Notification.Name(API_CLIENT_EVENTS["CLIENT_ERROR"]!),
+            NotificationCenter.default.post(name: Notification.Name(ApiEvents.CLIENT_ERROR.rawValue),
                                             object: nil,
                                             userInfo: ["serverUrl": sessionBaseUrlString, "errorCode": error._code, "errorDescription": error.localizedDescription])
         }
@@ -18,8 +18,12 @@ import Alamofire
     }
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest, withSessionBaseUrlString: session.baseUrl.absoluteString)
-
-        completion(.success(urlRequest))
+        if let baseUrl = session.baseUrl {
+            let urlRequest = BearerAuthenticationAdapter.addAuthorizationBearerToken(to: urlRequest, withSessionBaseUrlString: baseUrl.absoluteString)
+            
+            completion(.success(urlRequest))
+        } else {
+            completion(.failure(BaseURLError.missingBaseURL))
+        }
     }
 }

--- a/ios/Extensions/ApiClientError.swift
+++ b/ios/Extensions/ApiClientError.swift
@@ -3,6 +3,18 @@ import Foundation
 enum APIClientError: Error {
     case ClientCertificateMissing
     case ServerCertificateInvalid
+    case ServerTrustEvaluationFailed
+}
+
+enum BaseURLError: Error {
+    case missingBaseURL
+    
+    var errorDescription: String? {
+        switch self {
+        case .missingBaseURL:
+            return "The base URL has not been set"
+        }
+    }
 }
 
 extension APIClientError: LocalizedError {
@@ -10,6 +22,7 @@ extension APIClientError: LocalizedError {
         switch self {
         case .ClientCertificateMissing: return -200
         case .ServerCertificateInvalid: return -299
+        case .ServerTrustEvaluationFailed: return -298
         }
     }
     
@@ -19,6 +32,8 @@ extension APIClientError: LocalizedError {
             return "Failed to authenticate: missing client certificate"
         case .ServerCertificateInvalid:
             return "Invalid or not trusted server certificate"
+        case .ServerTrustEvaluationFailed:
+            return ""
         }
     }
 }

--- a/ios/Extensions/Session+Extensions.swift
+++ b/ios/Extensions/Session+Extensions.swift
@@ -13,8 +13,8 @@ fileprivate var trustSelfSignedServerCertificate_FILEPRIVATE : [ObjectIdentifier
 fileprivate var retryPolicy_FILEPRIVATE : [ObjectIdentifier:RetryPolicy] = [:]
 
 extension Session {
-    var baseUrl: URL {
-        get { return baseUrl_FILEPRIVATE[ObjectIdentifier(self)]!}
+    var baseUrl: URL? {
+        get { return baseUrl_FILEPRIVATE[ObjectIdentifier(self)]}
         set { baseUrl_FILEPRIVATE[ObjectIdentifier(self)] = newValue}
     }
 

--- a/ios/Extensions/SessionManager+Extensions.swift
+++ b/ios/Extensions/SessionManager+Extensions.swift
@@ -25,7 +25,7 @@ extension SessionManager {
                 throw APIClientError.ClientCertificateMissing
             }
         } catch {
-            NotificationCenter.default.post(name: Notification.Name(API_CLIENT_EVENTS["CLIENT_ERROR"]!),
+            NotificationCenter.default.post(name: Notification.Name(ApiEvents.CLIENT_ERROR.rawValue),
                                             object: nil,
                                             userInfo: ["serverUrl": baseUrl.absoluteString,
                                                        "errorCode": error._code,

--- a/ios/GenericClient/GenericClientWrapper.swift
+++ b/ios/GenericClient/GenericClientWrapper.swift
@@ -2,16 +2,8 @@ import Alamofire
 import SwiftyJSON
 
 @objc public class GenericClientWrapper: NSObject, NetworkClient {
-    var session: Session
+    let session: Session = Session(serverTrustManager: SessionManager.default.loadCertificates(), redirectHandler: Redirector(behavior: .follow))
     
-    public override init() {
-        if let serverTrustManager = SessionManager.default.serverTrustManager {
-            session = Session(serverTrustManager: serverTrustManager, redirectHandler: Redirector(behavior: .follow))
-        } else {
-            session = Session(redirectHandler: Redirector(behavior: .follow))
-        }
-    }
-
     @objc public func head(url: String, options: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         handleRequest(for: url, withMethod: .head, withSession: session, withOptions: JSON(options), withResolver: resolve, withRejecter: reject)
     }

--- a/ios/GenericClient/GenericClientWrapper.swift
+++ b/ios/GenericClient/GenericClientWrapper.swift
@@ -2,7 +2,15 @@ import Alamofire
 import SwiftyJSON
 
 @objc public class GenericClientWrapper: NSObject, NetworkClient {
-    var session = Session(redirectHandler: Redirector(behavior: .follow))
+    var session: Session
+    
+    public override init() {
+        if let serverTrustManager = SessionManager.default.serverTrustManager {
+            session = Session(serverTrustManager: serverTrustManager, redirectHandler: Redirector(behavior: .follow))
+        } else {
+            session = Session(redirectHandler: Redirector(behavior: .follow))
+        }
+    }
 
     @objc public func head(url: String, options: Dictionary<String, Any>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         handleRequest(for: url, withMethod: .head, withSession: session, withOptions: JSON(options), withResolver: resolve, withRejecter: reject)

--- a/ios/WebSocket/WebSocketEngine.swift
+++ b/ios/WebSocket/WebSocketEngine.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Alamofire
+import Starscream
+
+class WebSocketEngine: SessionDelegate, Engine {
+    private var task: URLSessionWebSocketTask?
+    private var clientCredential: URLCredential?
+    private var allowSelfSign: Bool
+    weak var delegate: EngineDelegate?
+    
+    typealias ChallengeEvaluation = (disposition: URLSession.AuthChallengeDisposition, credential: URLCredential?)
+
+    public init(clientCredential: URLCredential? = nil, allowSelfSignCertificate: Bool = false) {
+        self.clientCredential = clientCredential
+        self.allowSelfSign = allowSelfSignCertificate
+    }
+
+    public func register(delegate: EngineDelegate) {
+        self.delegate = delegate
+    }
+
+    public func start(request: URLRequest) {
+        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
+        task = session.webSocketTask(with: request)
+        doRead()
+        task?.resume()
+    }
+
+    public func stop(closeCode: UInt16) {
+        let closeCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(closeCode)) ?? .normalClosure
+        task?.cancel(with: closeCode, reason: nil)
+    }
+
+    public func forceStop() {
+        stop(closeCode: UInt16(URLSessionWebSocketTask.CloseCode.abnormalClosure.rawValue))
+    }
+
+    public func write(string: String, completion: (() -> ())?) {
+        task?.send(.string(string), completionHandler: { (error) in
+            completion?()
+        })
+    }
+
+    public func write(data: Data, opcode: FrameOpCode, completion: (() -> ())?) {
+        switch opcode {
+        case .binaryFrame:
+            task?.send(.data(data), completionHandler: { (error) in
+                completion?()
+            })
+        case .textFrame:
+            let text = String(data: data, encoding: .utf8)!
+            write(string: text, completion: completion)
+        case .ping:
+            task?.sendPing(pongReceiveHandler: { (error) in
+                completion?()
+            })
+        default:
+            break //unsupported
+        }
+    }
+
+    private func doRead() {
+        task?.receive { [weak self] (result) in
+            switch result {
+            case .success(let message):
+                switch message {
+                case .string(let string):
+                    self?.broadcast(event: .text(string))
+                case .data(let data):
+                    self?.broadcast(event: .binary(data))
+                @unknown default:
+                    break
+                }
+                break
+            case .failure(error: let err):
+                self?.broadcast(event: .error(err))
+                return
+            }
+            self?.doRead()
+        }
+    }
+
+    private func broadcast(event: WebSocketEvent) {
+        delegate?.didReceive(event: event)
+    }
+
+    override open func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        let p = `protocol` ?? ""
+        broadcast(event: .connected(["Sec-WebSocket-Protocol": p]))
+    }
+    
+    override open func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        var r = ""
+        if let d = reason {
+            r = String(data: d, encoding: .utf8) ?? ""
+        }
+        broadcast(event: .disconnected(r, UInt16(closeCode.rawValue)))
+    }
+
+    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        var evaluation: ChallengeEvaluation = (.performDefaultHandling, nil)
+        switch challenge.protectionSpace.authenticationMethod {
+        #if canImport(Security)
+        case NSURLAuthenticationMethodServerTrust:
+            if self.allowSelfSign {
+                evaluation = (.useCredential, URLCredential(trust: challenge.protectionSpace.serverTrust!))
+            } else {
+                evaluation = attemptServerTrustAuthentication(with: challenge)
+            }
+        case NSURLAuthenticationMethodClientCertificate:
+            if self.clientCredential != nil {
+                evaluation = (.useCredential, self.clientCredential)
+            }
+        #endif
+        default:
+            evaluation = (.performDefaultHandling, nil)
+        }
+
+        completionHandler(evaluation.disposition, evaluation.credential)
+    }
+    
+    public override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let nsError = error as NSError?
+        if nsError != nil && nsError?.code == -999 {
+            broadcast(event: .disconnected(nsError!.localizedDescription, UInt16(URLSessionWebSocketTask.CloseCode.tlsHandshakeFailure.rawValue)))
+            return
+        }
+        broadcast(event: .error(error))
+    }
+    
+    #if canImport(Security)
+    /// Evaluates the server trust `URLAuthenticationChallenge` received.
+    ///
+    /// - Parameter challenge: The `URLAuthenticationChallenge`.
+    ///
+    /// - Returns:             The `ChallengeEvaluation`.
+    func attemptServerTrustAuthentication(with challenge: URLAuthenticationChallenge) -> ChallengeEvaluation {
+        let host = challenge.protectionSpace.host
+        
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust
+        else {
+            return (.performDefaultHandling, nil)
+        }
+        
+        do {
+            guard let serverTrustManager = SessionManager.default.serverTrustManager else {
+                return (.performDefaultHandling, nil)
+            }
+            
+            guard let evaluator = try serverTrustManager.serverTrustEvaluator(forHost: host) else {
+                return (.performDefaultHandling, nil)
+            }
+
+            try evaluator.evaluate(trust, forHost: host)
+
+            return (.useCredential, URLCredential(trust: trust))
+        } catch {
+            return (.cancelAuthenticationChallenge, nil)
+        }
+    }
+    #endif
+}

--- a/ios/WebSocket/WebSocketEngine.swift
+++ b/ios/WebSocket/WebSocketEngine.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Alamofire
 import Starscream
+import os.log
 
 class WebSocketEngine: SessionDelegate, Engine {
     private var task: URLSessionWebSocketTask?
@@ -57,6 +58,11 @@ class WebSocketEngine: SessionDelegate, Engine {
                 completion?()
             })
         default:
+            os_log("Mattermost: WebSocket write operation opcode %@ is not supported",
+                   log: .default,
+                   type: .info,
+                   opcode.rawValue
+            )
             break //unsupported
         }
     }
@@ -71,6 +77,10 @@ class WebSocketEngine: SessionDelegate, Engine {
                 case .data(let data):
                     self?.broadcast(event: .binary(data))
                 @unknown default:
+                    os_log("Mattermost: WebSocket read operation is not of type string or data",
+                           log: .default,
+                           type: .info
+                    )
                     break
                 }
                 break

--- a/ios/WebSocket/WebSocketEngine.swift
+++ b/ios/WebSocket/WebSocketEngine.swift
@@ -6,13 +6,15 @@ class WebSocketEngine: SessionDelegate, Engine {
     private var task: URLSessionWebSocketTask?
     private var clientCredential: URLCredential?
     private var allowSelfSign: Bool
+    private var serverTrustManager: ServerTrustManager?
     weak var delegate: EngineDelegate?
     
     typealias ChallengeEvaluation = (disposition: URLSession.AuthChallengeDisposition, credential: URLCredential?)
 
-    public init(clientCredential: URLCredential? = nil, allowSelfSignCertificate: Bool = false) {
+    public init(forHost host: String?, clientCredential: URLCredential? = nil, allowSelfSignCertificate: Bool = false) {
         self.clientCredential = clientCredential
         self.allowSelfSign = allowSelfSignCertificate
+        self.serverTrustManager = SessionManager.default.loadCertificates(forDomain: host)
     }
 
     public func register(delegate: EngineDelegate) {
@@ -144,7 +146,7 @@ class WebSocketEngine: SessionDelegate, Engine {
         }
         
         do {
-            guard let serverTrustManager = SessionManager.default.serverTrustManager else {
+            guard let serverTrustManager = self.serverTrustManager else {
                 return (.performDefaultHandling, nil)
             }
             

--- a/ios/WebSocket/WebSocketManager.swift
+++ b/ios/WebSocket/WebSocketManager.swift
@@ -21,7 +21,7 @@ class WebSocketManager: NSObject {
         var request = URLRequest(url: url)
         var compressionHandler: CompressionHandler? = nil
         var clientCredential: URLCredential? = nil
-        var certPinner = FoundationSecurity()
+        var allowSelfSign = false
 
         let options = JSON(options)
         if options != JSON.null {
@@ -51,16 +51,12 @@ class WebSocketManager: NSObject {
                 clientCredential = URLCredential(identity: identity, certificates: [certificate], persistence: URLCredential.Persistence.permanent)
             }
             
-            if options["enableCompression"].boolValue {
-                compressionHandler = WSCompression()
-            }
-            
             if options["trustSelfSignedServerCertificate"].boolValue {
-                certPinner = FoundationSecurity(allowSelfSigned: true)
+                allowSelfSign = true
             }
         }
 
-        let webSocket = WebSocket(request: request, certPinner: certPinner, clientCredential: clientCredential, compressionHandler: compressionHandler)
+        let webSocket = WebSocket(request: request, engine: WebSocketEngine(clientCredential: clientCredential, allowSelfSignCertificate: allowSelfSign))
         webSocket.delegate = delegate
         
         webSockets[url] = webSocket

--- a/ios/WebSocket/WebSocketManager.swift
+++ b/ios/WebSocket/WebSocketManager.swift
@@ -56,7 +56,7 @@ class WebSocketManager: NSObject {
             }
         }
 
-        let webSocket = WebSocket(request: request, engine: WebSocketEngine(clientCredential: clientCredential, allowSelfSignCertificate: allowSelfSign))
+        let webSocket = WebSocket(request: request, engine: WebSocketEngine(forHost: url.host, clientCredential: clientCredential, allowSelfSignCertificate: allowSelfSign))
         webSocket.delegate = delegate
         
         webSockets[url] = webSocket

--- a/ios/WebSocket/WebSocketWrapper.swift
+++ b/ios/WebSocket/WebSocketWrapper.swift
@@ -180,7 +180,7 @@ var READY_STATE = [
                 delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": error?.localizedDescription as Any, "code": errorCode as Any]])
             } else {
                 let errorDetails: [String: Any] = [
-                    "message": nsError!.description,
+                    "message": nsError?.description,
                 ]
                 delegate?.sendEvent(name: WSEvents.ERROR_EVENT.rawValue, result: ["url": url, "message": ["error": errorDetails]])
             }


### PR DESCRIPTION
#### Summary
As part of some of the requirements by XXXXX we needed to add support for SSL Pinning when building your own app.

The way is being built is a combination of the app and the network-client library, the app will hold the certificate assets while the network-library will use these certs to verify the server trust.

The cert files should have either a `.crt` or `.cer` extension while the name of the file must be the domain name.

The reason we support two files extensions per domain is to be able to build the app taking into account server cert rotation and minimizing the amount of app distribution through updates in order to validate the certs.

This SSL Pinning certificates should be included in the app at build time.



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59055
