### PR TITLE
Migrate SharedPreferences to DataStore

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,4 +64,5 @@ dependencies {
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
   implementation "com.squareup.okhttp3:okhttp-tls:4.12.0"
   implementation "com.squareup.okhttp3:okhttp-urlconnection:4.12.0"
+  implementation "androidx.datastore:datastore-preferences:1.1.1"
 }


### PR DESCRIPTION
#### Summary
On Android we were using SharedPreferences to store the client certs and the session tokens but now the recommended way is to use [DataStore](https://developer.android.com/topic/libraries/architecture/datastore) instead

This PR migrates the current SharedPreferences to DataStore and starts using DataStore from this point onwards.