### PR TITLE
fix(android): move from ReactApplicationContext to Context to use the library from native code

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -1,6 +1,7 @@
 package com.mattermost.networkclient
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import android.webkit.CookieManager
@@ -43,7 +44,7 @@ import kotlin.reflect.KProperty
 
 const val CERTIFICATES_PATH = "certs"
 
-internal class NetworkClient(private val context: ReactApplicationContext, private val baseUrl: HttpUrl? = null, options: ReadableMap? = null, cookieJar: CookieJar? = null) {
+internal class NetworkClient(private val context: Context, private val baseUrl: HttpUrl? = null, options: ReadableMap? = null, cookieJar: CookieJar? = null) {
     private var okHttpClient: OkHttpClient
     private var webSocketUri: URI? = null
 


### PR DESCRIPTION
#### Summary
In some cases where the app is not running we were hitting the issue `ERROR ReactNative: Error processing push notification error=Attempt to invoke virtual method 'boolean com.mattermost.networkclient.ApiClientModuleImpl.hasClientFor(okhttp3.HttpUrl)' on a null object reference`

basically this happened as the module was not initialized, so now we are forcing it to init in some places where the context is available but it cannot be cast as ReactApplicationContext, this changes ensures that the available context is capable of initializing the module.

Once this PR is merged and library release will be submitting the next PR that goes with this.