### PR TITLE
fix(android): fix unresolved promises on websocket client

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
@@ -99,11 +99,11 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
 
         try {
             clients[wsUri]!!.createWebSocket()
+            promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)
         }
 
-        promise.resolve(null)
     }
 
     fun disconnectFor(wsUrl: String, promise: Promise) {
@@ -116,11 +116,10 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
 
         try {
             clients[wsUri]!!.webSocket!!.cancel()
+            promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)
         }
-
-        promise.resolve(null)
     }
 
     fun sendDataFor(wsUrl: String, data: String, promise: Promise) {
@@ -134,11 +133,11 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
 
         try {
             clients[wsUri]!!.webSocket!!.send(data)
+            promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)
         }
 
-        promise.resolve(null)
     }
 
     /**

--- a/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
@@ -102,6 +102,8 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
         } catch (error: Exception) {
             promise.reject(error)
         }
+
+        promise.resolve(null)
     }
 
     fun disconnectFor(wsUrl: String, promise: Promise) {
@@ -117,6 +119,8 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
         } catch (error: Exception) {
             promise.reject(error)
         }
+
+        promise.resolve(null)
     }
 
     fun sendDataFor(wsUrl: String, data: String, promise: Promise) {
@@ -133,6 +137,8 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
         } catch (error: Exception) {
             promise.reject(error)
         }
+
+        promise.resolve(null)
     }
 
     /**

--- a/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
@@ -103,7 +103,6 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
         } catch (error: Exception) {
             promise.reject(error)
         }
-
     }
 
     fun disconnectFor(wsUrl: String, promise: Promise) {
@@ -137,7 +136,6 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
         } catch (error: Exception) {
             promise.reject(error)
         }
-
     }
 
     /**


### PR DESCRIPTION
#### Summary
By chance saw a message in the logs about "Excesive number of pending callbacks", pointing to "sendDataFor" on the "WebsocketClient".

After checking the code, I saw we are not resolving some of the promises for the websocket client. This fixes that.

#### Ticket Link
NONE
