### PR TITLE
Some servers drop connections from time to time.

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -137,7 +137,7 @@ internal class NetworkClient(private val context: Context, private val baseUrl: 
 
         builder.followRedirects(false)
         builder.followSslRedirects(false)
-        builder.retryOnConnectionFailure(false)
+        builder.retryOnConnectionFailure(true)
         builder.addInterceptor(RuntimeInterceptor(this, "retry"))
         builder.addInterceptor(RuntimeInterceptor(this, "timeout"))
 


### PR DESCRIPTION
#### Summary

This the root-cause of the problem this PR was solving. https://github.com/mattermost/mattermost-mobile/pull/8966 

okHttp was configured to just drop the connection, so Android users on bad connection or complicated network hosting solutions would end up with messages being dropped randomly (they would have to try and resend them from the app).

This behavior wasn't exhibited on the desktop clients. This change makes them behave the same way.


#### Ticket Link

https://github.com/mattermost/mattermost-mobile/issues/8964
