### PR TITLE
Remove incorrect certificate warning

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -245,9 +245,6 @@ internal class NetworkClient(private val context: Context, private val baseUrl: 
                         rejectInvalidCertificate(promise, request.url.host)
                         return
                     }
-                } else if (e is javax.net.ssl.SSLHandshakeException) {
-                    rejectInvalidCertificate(promise, request.url.host)
-                    return
                 }
                 promise.reject(e)
             }


### PR DESCRIPTION
#### Summary
`javax.net.ssl.SSLHandshakeException` can be thrown for a variety of reasons unrelated to the certificate being invalid - most notably socket errors while trying to negotiate the TLS session. This can result in spurious warnings about the remote host serving an invalid certificate when a connection is closed remotely, and can easily be triggered by a network change.

Given the certificate is validated elsewhere we can trust that users will be warned appropriately so removing this unnecessary warning path is the cleanest fix - handling all relevant sub-errors would be very ugly.