### PR TITLE
fix(android): Crash on Arabic locale due to non-ASCII characters in HTTP header

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -3,6 +3,7 @@ package com.mattermost.networkclient.interceptors
 import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import java.util.Locale
 
 class CompressedResponseSizeInterceptor: Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -37,7 +38,7 @@ class CompressedResponseSizeInterceptor: Interceptor {
             .header("X-Compressed-Size", compressedSize.toString())
             .header("X-Start-Time", startTime.toString())
             .header("X-End-Time", endTime.toString())
-            .header("X-Speed-Mbps", "%.4f".format(speedMbps)) // Format to 4 decimal places
+            .header("X-Speed-Mbps", "%.4f".format(Locale.ENGLISH, speedMbps)) // Format to 4 decimal places
             .build()
     }
 }


### PR DESCRIPTION
### Summary
Fixes a crash that occurred when the android device locale was set to Arabic. The Mattermost Android app crashes immediately after launch due to an `IllegalArgumentException` thrown by OkHttp when parsing the `X-Speed-Mbps` response header.

### Problem
In `CompressedResponseSizeInterceptor.kt`, the speed value was formatted using the default system locale:

```kotlin
.header("X-Speed-Mbps", "%.4f".format(speedMbps))
```

On devices with an **Arabic locale**, the default number formatter produces **Eastern-Arabic numerals** (e.g. `٠٫٠٠٢٨`) instead of ASCII digits (e.g. `0.0028`). OkHttp strictly validates HTTP header values and only accepts ASCII characters, causing the following crash:

```
java.lang.IllegalArgumentException: Unexpected char 0x660 at 0 in X-Speed-Mbps value: ٠٫٠٠٢٨
    at okhttp3.Headers$Companion.checkValue(Headers.kt:450)
    at com.mattermost.networkclient.interceptors.CompressedResponseSizeInterceptor.intercept(CompressedResponseSizeInterceptor.kt:40)
```

### Fix
Explicitly pass `Locale.ENGLISH` to the format call to ensure the speed value is always formatted using ASCII digits, regardless of the device locale:

```kotlin
.header("X-Speed-Mbps", "%.4f".format(Locale.ENGLISH, speedMbps))
```

### Changes
- `CompressedResponseSizeInterceptor.kt`: Added `import java.util.Locale` and passed `Locale.ENGLISH` to the `format` call for the `X-Speed-Mbps` header value.

### Issues
Fixes https://github.com/mattermost/mattermost-mobile/issues/9574
Fixes https://github.com/mattermost/mattermost-mobile/issues/9576