### PR TITLE
Add sendBinary() to WebSocketClient

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
+++ b/android/src/main/java/com/mattermost/networkclient/WebSocketClientModuleImpl.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReadableMap
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.net.URI
+import java.net.URISyntaxException
 
 class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext) {
     private val clients = mutableMapOf<URI, NetworkClient>()
@@ -132,6 +133,23 @@ class WebSocketClientModuleImpl(reactApplicationContext: ReactApplicationContext
 
         try {
             clients[wsUri]!!.webSocket!!.send(data)
+            promise.resolve(null)
+        } catch (error: Exception) {
+            promise.reject(error)
+        }
+    }
+
+    fun sendBinaryDataFor(wsUrl: String, data: String, promise: Promise) {
+        val wsUri: URI
+        try {
+            wsUri = URI(wsUrl)
+        } catch (error: URISyntaxException) {
+            return promise.reject(error)
+        }
+
+        try {
+            val bytes = android.util.Base64.decode(data, android.util.Base64.DEFAULT)
+            clients[wsUri]!!.webSocket!!.send(okio.ByteString.of(*bytes))
             promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)

--- a/android/src/newarch/java/com/WebSocketClientModule.kt
+++ b/android/src/newarch/java/com/WebSocketClientModule.kt
@@ -71,4 +71,12 @@ internal class WebSocketClientModule(reactContext: ReactApplicationContext) : Na
         implementation.invalidateClientFor(url, promise)
     }
 
+    override fun sendBinaryDataFor(url: String?, data: String?, promise: Promise?) {
+        if (url.isNullOrEmpty() || data.isNullOrEmpty() || promise == null) {
+            promise?.reject(Exception("missing parameter to send binary data"))
+            return
+        }
+        implementation.sendBinaryDataFor(url, data, promise)
+    }
+
 }

--- a/android/src/oldarch/java/com/WebSocketClientModule.kt
+++ b/android/src/oldarch/java/com/WebSocketClientModule.kt
@@ -47,6 +47,11 @@ internal class WebSocketClientModule(reactContext: ReactApplicationContext) : Re
     }
 
     @ReactMethod
+    fun sendBinaryDataFor(wsUrl: String, data: String, promise: Promise) {
+        implementation.sendBinaryDataFor(wsUrl, data, promise)
+    }
+
+    @ReactMethod
     fun addListener(eventName: String) {
         // Keep: Required for RN built in Event Emitter Calls
     }

--- a/android/src/test/java/com/mattermost/networkclient/WebSocketClientModuleImplTest.kt
+++ b/android/src/test/java/com/mattermost/networkclient/WebSocketClientModuleImplTest.kt
@@ -1,0 +1,35 @@
+package com.mattermost.networkclient
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import java.net.URISyntaxException
+
+class WebSocketClientModuleImplTest {
+    private lateinit var impl: WebSocketClientModuleImpl
+    private lateinit var promise: Promise
+
+    @Before
+    fun setUp() {
+        val mockContext = mock(ReactApplicationContext::class.java)
+        impl = WebSocketClientModuleImpl(mockContext)
+        promise = mock(Promise::class.java)
+    }
+
+    // Happy-path binary sends require a live WebSocket connection and android.util.Base64,
+    // which are only available in instrumented (on-device) tests. The base64 encoding and
+    // binary frame delivery are covered end-to-end by the mattermost-mobile test suite.
+
+    @Test
+    fun `sendBinaryDataFor rejects promise for malformed URL`() {
+        impl.sendBinaryDataFor("not a valid uri", "dGVzdA==", promise)
+
+        val captor = ArgumentCaptor.forClass(Throwable::class.java)
+        verify(promise).reject(captor.capture())
+        assert(captor.value is URISyntaxException)
+    }
+}

--- a/ios/WebSocket/WebSocketClientImpl.mm
+++ b/ios/WebSocket/WebSocketClientImpl.mm
@@ -67,6 +67,10 @@ RCT_EXPORT_METHOD(sendDataFor:(NSString *)url withData:(NSString *)data withReso
     [wrapper sendDataForUrlString:url data:data resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(sendBinaryDataFor:(NSString *)url withData:(NSString *)data withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject) {
+    [wrapper sendBinaryDataForUrlString:url data:data resolve:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(invalidateClientFor:(NSString *)url withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject) {
     [wrapper invalidateClientForUrlString:url resolve:resolve reject:reject];
 }
@@ -164,8 +168,12 @@ RCT_EXPORT_METHOD(invalidateClientFor:(NSString *)url withResolver:(RCTPromiseRe
     [wrapper invalidateClientForUrlString:url resolve:resolve reject:reject];
 }
 
-- (void)sendDataFor:(NSString *)url data:(NSString *)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject { 
+- (void)sendDataFor:(NSString *)url data:(NSString *)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     [wrapper sendDataForUrlString:url data:data resolve:resolve reject:reject];
+}
+
+- (void)sendBinaryDataFor:(NSString *)url data:(NSString *)data resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    [wrapper sendBinaryDataForUrlString:url data:data resolve:resolve reject:reject];
 }
 
 @end

--- a/ios/WebSocket/WebSocketWrapper.swift
+++ b/ios/WebSocket/WebSocketWrapper.swift
@@ -107,6 +107,28 @@ var READY_STATE = [
         resolve(webSocket.write(string: data))    
     }
 
+    @objc public func sendBinaryDataFor(urlString: String, data: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        guard let url = URL(string: urlString) else {
+            rejectMalformed(url: urlString, withRejecter: reject)
+            return
+        }
+
+        guard let webSocket = WebSocketManager.default.getWebSocket(for: url) else {
+            rejectInvalidWebSocket(for: url, withRejecter: reject)
+            return
+        }
+
+        guard let binaryData = Data(base64Encoded: data) else {
+            let err = NSError(domain: NSCocoaErrorDomain, code: NSCoderValueNotFoundError,
+                              userInfo: [NSLocalizedDescriptionKey: "Invalid base64 data"])
+            reject("\(err.code)", "Invalid base64 data", err)
+            return
+        }
+
+        webSocket.write(data: binaryData)
+        resolve(nil)
+    }
+
     @objc public func invalidateClientFor(urlString: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         guard let url = URL(string: urlString) else {
             rejectMalformed(url: urlString, withRejecter: reject)

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@react-native|react-native|validator)/)"
     ]
   },
   "commitlint": {

--- a/src/WebSocketClient/NativeWebSocketClient.ts
+++ b/src/WebSocketClient/NativeWebSocketClient.ts
@@ -48,6 +48,7 @@ export interface Spec extends TurboModule {
     connectFor: (url: string) => Promise<void>;
     disconnectFor(url: string): Promise<void>;
     sendDataFor(url: string, data: string): Promise<void>;
+    sendBinaryDataFor(url: string, data: string): Promise<void>;
     invalidateClientFor(url: string): Promise<void>;
 }
 

--- a/src/WebSocketClient/__tests__/WebSocketClient.test.ts
+++ b/src/WebSocketClient/__tests__/WebSocketClient.test.ts
@@ -1,12 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getOrCreateWebSocketClient} from '../index';
-import NativeWebSocketClient from '../NativeWebSocketClient';
+import { getOrCreateWebSocketClient } from "../index";
+import NativeWebSocketClient from "../NativeWebSocketClient";
 
-const mockNativeClient = NativeWebSocketClient as jest.Mocked<typeof NativeWebSocketClient>;
+const mockNativeClient = NativeWebSocketClient as jest.Mocked<
+    typeof NativeWebSocketClient
+>;
 
-jest.mock('../NativeWebSocketClient', () => ({
+jest.mock("../NativeWebSocketClient", () => ({
     __esModule: true,
     default: {
         addListener: jest.fn(),
@@ -18,52 +20,59 @@ jest.mock('../NativeWebSocketClient', () => ({
         sendBinaryDataFor: jest.fn().mockResolvedValue(undefined),
         invalidateClientFor: jest.fn().mockResolvedValue(undefined),
     },
-    WebSocketReadyState: {CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3},
+    WebSocketReadyState: { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
     WebSocketEvents: {
-        OPEN_EVENT: 'WebSocketClient-Open',
-        CLOSE_EVENT: 'WebSocketClient-Close',
-        ERROR_EVENT: 'WebSocketClient-Error',
-        MESSAGE_EVENT: 'WebSocketClient-Message',
-        READY_STATE_EVENT: 'WebSocketClient-ReadyState',
+        OPEN_EVENT: "WebSocketClient-Open",
+        CLOSE_EVENT: "WebSocketClient-Close",
+        ERROR_EVENT: "WebSocketClient-Error",
+        MESSAGE_EVENT: "WebSocketClient-Message",
+        READY_STATE_EVENT: "WebSocketClient-ReadyState",
     },
 }));
 
 // Each test uses a unique URL to avoid the module-level CLIENTS singleton state.
 let urlCounter = 0;
-const nextUrl = () => `ws://mattermost.example.com/api/v4/websocket?t=${++urlCounter}`;
+const nextUrl = () =>
+    `ws://mattermost.example.com/api/v4/websocket?t=${++urlCounter}`;
 
-describe('WebSocketClient', () => {
+describe("WebSocketClient", () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should call sendDataFor when send() is invoked', async () => {
+    it("should call sendDataFor when send() is invoked", async () => {
         const url = nextUrl();
-        const {client} = await getOrCreateWebSocketClient(url);
+        const { client } = await getOrCreateWebSocketClient(url);
 
-        client.send('hello');
+        client.send("hello");
 
-        expect(mockNativeClient.sendDataFor).toHaveBeenCalledWith(url, 'hello');
+        expect(mockNativeClient.sendDataFor).toHaveBeenCalledWith(url, "hello");
     });
 
-    it('should call sendBinaryDataFor when sendBinary() is invoked', async () => {
+    it("should call sendBinaryDataFor when sendBinary() is invoked", async () => {
         const url = nextUrl();
-        const {client} = await getOrCreateWebSocketClient(url);
-        const base64Data = 'SGVsbG8gV29ybGQ=';
+        const { client } = await getOrCreateWebSocketClient(url);
+        const base64Data = "SGVsbG8gV29ybGQ=";
 
         client.sendBinary(base64Data);
 
-        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(url, base64Data);
+        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(
+            url,
+            base64Data,
+        );
     });
 
-    it('should pass the exact url and data to sendBinaryDataFor', async () => {
+    it("should pass the exact url and data to sendBinaryDataFor", async () => {
         const url = nextUrl();
-        const {client} = await getOrCreateWebSocketClient(url);
-        const encoded = 'dGVzdA==';
+        const { client } = await getOrCreateWebSocketClient(url);
+        const encoded = "dGVzdA==";
 
         client.sendBinary(encoded);
 
         expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledTimes(1);
-        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(url, encoded);
+        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(
+            url,
+            encoded,
+        );
     });
 });

--- a/src/WebSocketClient/__tests__/WebSocketClient.test.ts
+++ b/src/WebSocketClient/__tests__/WebSocketClient.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getOrCreateWebSocketClient} from '../index';
+import NativeWebSocketClient from '../NativeWebSocketClient';
+
+const mockNativeClient = NativeWebSocketClient as jest.Mocked<typeof NativeWebSocketClient>;
+
+jest.mock('../NativeWebSocketClient', () => ({
+    __esModule: true,
+    default: {
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+        ensureClientFor: jest.fn().mockResolvedValue(undefined),
+        connectFor: jest.fn().mockResolvedValue(undefined),
+        disconnectFor: jest.fn().mockResolvedValue(undefined),
+        sendDataFor: jest.fn().mockResolvedValue(undefined),
+        sendBinaryDataFor: jest.fn().mockResolvedValue(undefined),
+        invalidateClientFor: jest.fn().mockResolvedValue(undefined),
+    },
+    WebSocketReadyState: {CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3},
+    WebSocketEvents: {
+        OPEN_EVENT: 'WebSocketClient-Open',
+        CLOSE_EVENT: 'WebSocketClient-Close',
+        ERROR_EVENT: 'WebSocketClient-Error',
+        MESSAGE_EVENT: 'WebSocketClient-Message',
+        READY_STATE_EVENT: 'WebSocketClient-ReadyState',
+    },
+}));
+
+// Each test uses a unique URL to avoid the module-level CLIENTS singleton state.
+let urlCounter = 0;
+const nextUrl = () => `ws://mattermost.example.com/api/v4/websocket?t=${++urlCounter}`;
+
+describe('WebSocketClient', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call sendDataFor when send() is invoked', async () => {
+        const url = nextUrl();
+        const {client} = await getOrCreateWebSocketClient(url);
+
+        client.send('hello');
+
+        expect(mockNativeClient.sendDataFor).toHaveBeenCalledWith(url, 'hello');
+    });
+
+    it('should call sendBinaryDataFor when sendBinary() is invoked', async () => {
+        const url = nextUrl();
+        const {client} = await getOrCreateWebSocketClient(url);
+        const base64Data = 'SGVsbG8gV29ybGQ=';
+
+        client.sendBinary(base64Data);
+
+        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(url, base64Data);
+    });
+
+    it('should pass the exact url and data to sendBinaryDataFor', async () => {
+        const url = nextUrl();
+        const {client} = await getOrCreateWebSocketClient(url);
+        const encoded = 'dGVzdA==';
+
+        client.sendBinary(encoded);
+
+        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledTimes(1);
+        expect(mockNativeClient.sendBinaryDataFor).toHaveBeenCalledWith(url, encoded);
+    });
+});

--- a/src/WebSocketClient/index.tsx
+++ b/src/WebSocketClient/index.tsx
@@ -54,6 +54,7 @@ class WebSocketClient implements WebSocketClientInterface {
         return NativeWebSocketClient.disconnectFor(this.url);
     };
     send = (data: string) => NativeWebSocketClient.sendDataFor(this.url, data);
+    sendBinary = (data: string) => NativeWebSocketClient.sendBinaryDataFor(this.url, data);
 
     onOpen = (callback: WebSocketEventHandler) => {
         if (this.onWebSocketOpenSubscription) {

--- a/src/WebSocketClient/index.tsx
+++ b/src/WebSocketClient/index.tsx
@@ -54,7 +54,8 @@ class WebSocketClient implements WebSocketClientInterface {
         return NativeWebSocketClient.disconnectFor(this.url);
     };
     send = (data: string) => NativeWebSocketClient.sendDataFor(this.url, data);
-    sendBinary = (data: string) => NativeWebSocketClient.sendBinaryDataFor(this.url, data);
+    sendBinary = (data: string) =>
+        NativeWebSocketClient.sendBinaryDataFor(this.url, data);
 
     onOpen = (callback: WebSocketEventHandler) => {
         if (this.onWebSocketOpenSubscription) {

--- a/src/types/WebSocketClient.ts
+++ b/src/types/WebSocketClient.ts
@@ -41,6 +41,7 @@ export interface WebSocketClientInterface {
     onWebSocketClientErrorSubscription?: EmitterSubscription;
 
     send(data: string): void;
+    sendBinary?(data: string): void;
     open(): void;
     close(): void;
     onOpen(callback: WebSocketEventHandler): void;


### PR DESCRIPTION
#### Summary
Adds sendBinary(base64Data: string) to the WebSocketClient API, which sends a binary WebSocket frame with the provided base64-encoded payload. Calls on mattermost-mobile needs to send binary SDP frames over WebSocket during call signaling. Calls previously used SocketRocket/CFStream WebSocket implementation which supported binary sending, no longer usable due to lack of TLS 1.3 support on iOS.

Note: the testing is very superficial, and I considered rolling it back. The mobile repos has testing for this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67958
