### PR TITLE
[MM-67999] fix websocket crash

### DIFF
--- a/ios/WebSocket/WebSocketManager.swift
+++ b/ios/WebSocket/WebSocketManager.swift
@@ -5,19 +5,14 @@ import SwiftyJSON
 class WebSocketManager: NSObject {
     static let `default` = WebSocketManager()
     private override init() {}
-    internal var webSockets: [URL: WebSocket] = [:]
-    
+    private var webSockets: [URL: WebSocket] = [:]
+    private let queue = DispatchQueue(label: "com.mattermost.react-native-network-client.websocket-manager")
+
     func webSocketCount() -> Int {
-        return webSockets.count
+        return queue.sync { webSockets.count }
     }
-    
+
     func createWebSocket(for url:URL, withOptions options: Dictionary<String, Any>, withDelegate delegate: WebSocketWrapper) throws -> Void {
-        let existingWebSocket = getWebSocket(for: url)
-        if (existingWebSocket != nil) {
-            existingWebSocket!.delegate = delegate
-            return
-        }
-        
         var request = URLRequest(url: url)
         var compressionHandler: CompressionHandler? = nil
         var clientCredential: URLCredential? = nil
@@ -30,15 +25,15 @@ class WebSocketManager: NSObject {
                     request.addValue(value.stringValue, forHTTPHeaderField: key)
                 }
             }
-            
+
             if let timeoutInterval = options["timeoutInterval"].double {
                 request.timeoutInterval = timeoutInterval / 1000
             }
-            
+
             if let clientP12Configuration = options["clientP12Configuration"].dictionaryObject as? [String:String] {
                 let path = clientP12Configuration["path"]
                 let password = clientP12Configuration["password"]
-                
+
                 do {
                     try Keychain.importClientP12(withPath: path!, withPassword: password, forHost: url.host!)
                 } catch KeychainError.DuplicateIdentity {
@@ -50,7 +45,7 @@ class WebSocketManager: NSObject {
                 let (identity, certificate) = try Keychain.getClientIdentityAndCertificate(for: url.host!)!
                 clientCredential = URLCredential(identity: identity, certificates: [certificate], persistence: URLCredential.Persistence.permanent)
             }
-            
+
             if options["trustSelfSignedServerCertificate"].boolValue {
                 allowSelfSign = true
             }
@@ -58,25 +53,29 @@ class WebSocketManager: NSObject {
 
         let webSocket = WebSocket(request: request, engine: WebSocketEngine(forHost: url.host, clientCredential: clientCredential, allowSelfSignCertificate: allowSelfSign))
         webSocket.delegate = delegate
-        
-        webSockets[url] = webSocket
-    }
-    
-    func getWebSocket(for url:URL) -> WebSocket? {
-        return webSockets[url]
-    }
-    
-    func disconnectAll() -> Void {
-        for ws in webSockets {
-            ws.value.disconnect()
+
+        queue.sync {
+            if let existing = webSockets[url] {
+                existing.delegate = delegate
+                webSocket.delegate = nil
+            } else {
+                webSockets[url] = webSocket
+            }
         }
     }
 
+    func getWebSocket(for url:URL) -> WebSocket? {
+        return queue.sync { webSockets[url] }
+    }
+
     func invalidateClient(for url:URL) -> Void {
-        guard let webSocket = getWebSocket(for: url) else {
+        let webSocket: WebSocket? = queue.sync {
+            return webSockets.removeValue(forKey: url)
+        }
+        guard let webSocket = webSocket else {
             return
         }
-        
+
         if let _ = try? Keychain.getClientIdentityAndCertificate(for: url.host!) {
             do {
                 try Keychain.deleteClientP12(for: url.host!)
@@ -88,11 +87,16 @@ class WebSocketManager: NSObject {
         }
         webSocket.forceDisconnect()
         webSocket.delegate = nil
-        webSockets.removeValue(forKey: url)
     }
 
     func invalidateContext() -> Void {
-        disconnectAll()
-        webSockets.removeAll()
+        let snapshot: [WebSocket] = queue.sync {
+            let values = Array(webSockets.values)
+            webSockets.removeAll()
+            return values
+        }
+        for ws in snapshot {
+            ws.disconnect()
+        }
     }
 }

--- a/ios/WebSocket/WebSocketManager.swift
+++ b/ios/WebSocket/WebSocketManager.swift
@@ -13,6 +13,15 @@ class WebSocketManager: NSObject {
     }
 
     func createWebSocket(for url:URL, withOptions options: Dictionary<String, Any>, withDelegate delegate: WebSocketWrapper) throws -> Void {
+        let reused: Bool = queue.sync {
+            if let existing = webSockets[url] {
+                existing.delegate = delegate
+                return true
+            }
+            return false
+        }
+        if reused { return }
+
         var request = URLRequest(url: url)
         var compressionHandler: CompressionHandler? = nil
         var clientCredential: URLCredential? = nil
@@ -69,10 +78,7 @@ class WebSocketManager: NSObject {
     }
 
     func invalidateClient(for url:URL) -> Void {
-        let webSocket: WebSocket? = queue.sync {
-            return webSockets.removeValue(forKey: url)
-        }
-        guard let webSocket = webSocket else {
+        guard let webSocket = getWebSocket(for: url) else {
             return
         }
 
@@ -87,6 +93,7 @@ class WebSocketManager: NSObject {
         }
         webSocket.forceDisconnect()
         webSocket.delegate = nil
+        queue.sync { webSockets.removeValue(forKey: url) }
     }
 
     func invalidateContext() -> Void {

--- a/ios/WebSocket/WebSocketWrapper.swift
+++ b/ios/WebSocket/WebSocketWrapper.swift
@@ -149,25 +149,26 @@ var READY_STATE = [
     // MARK: WebSocketDelegate methods
     
     public func didReceive(event: WebSocketEvent, client: Starscream.WebSocketClient) {
-        guard let url = client.url(), let delegate = self.delegate else { return }
+        guard let url = client.url() else { return }
+        let delegate = self.delegate
 
         switch event {
         case .connected(let headers):
-            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["OPEN"]!])
-            delegate.sendEvent(name: WSEvents.OPEN_EVENT.rawValue, result: ["url": url, "message": ["headers": headers]])
+            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["OPEN"]!])
+            delegate?.sendEvent(name: WSEvents.OPEN_EVENT.rawValue, result: ["url": url, "message": ["headers": headers]])
             errorCounter.removeValue(forKey: url)
         case .disconnected(let reason, let code):
-            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-            delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": reason, "code": code]])
+            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+            delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": reason, "code": code]])
         case .text(let text):
             if let data = text.data(using: .utf16), let json = JSON(data).dictionaryObject {
-                delegate.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": json])
+                delegate?.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": json])
             } else {
-                delegate.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": text])
+                delegate?.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": text])
             }
         case .cancelled:
-            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-            delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url])
+            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+            delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url])
             client.disconnect(closeCode: 1001)
         case .error(let error):
             let nsError = error as NSError?
@@ -175,13 +176,13 @@ var READY_STATE = [
             if ((errorCode == 61 || errorCode == 57) && (errorCounter[url] ?? 0) % 2 == 0) {
                 let count = errorCounter[url] ?? 0
                 errorCounter[url] = count + 1
-                delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-                delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": error?.localizedDescription as Any, "code": errorCode as Any]])
+                delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+                delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": error?.localizedDescription as Any, "code": errorCode as Any]])
             } else {
                 let errorDetails: [String: Any] = [
                     "message": nsError?.description,
                 ]
-                delegate.sendEvent(name: WSEvents.ERROR_EVENT.rawValue, result: ["url": url, "message": ["error": errorDetails]])
+                delegate?.sendEvent(name: WSEvents.ERROR_EVENT.rawValue, result: ["url": url, "message": ["error": errorDetails]])
             }
         case .viabilityChanged(let viable):
             print("Websocket viable \(viable)")

--- a/ios/WebSocket/WebSocketWrapper.swift
+++ b/ios/WebSocket/WebSocketWrapper.swift
@@ -149,26 +149,25 @@ var READY_STATE = [
     // MARK: WebSocketDelegate methods
     
     public func didReceive(event: WebSocketEvent, client: Starscream.WebSocketClient) {
-        
-        guard let url = client.url() else { return }
+        guard let url = client.url(), let delegate = self.delegate else { return }
 
         switch event {
         case .connected(let headers):
-            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["OPEN"]!])
-            delegate?.sendEvent(name: WSEvents.OPEN_EVENT.rawValue, result: ["url": url, "message": ["headers": headers]])
+            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["OPEN"]!])
+            delegate.sendEvent(name: WSEvents.OPEN_EVENT.rawValue, result: ["url": url, "message": ["headers": headers]])
             errorCounter.removeValue(forKey: url)
         case .disconnected(let reason, let code):
-            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-            delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": reason, "code": code]])
+            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+            delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": reason, "code": code]])
         case .text(let text):
             if let data = text.data(using: .utf16), let json = JSON(data).dictionaryObject {
-                delegate?.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": json])
+                delegate.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": json])
             } else {
-                delegate?.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": text])
+                delegate.sendEvent(name: WSEvents.MESSAGE_EVENT.rawValue, result: ["url": url, "message": text])
             }
         case .cancelled:
-            delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-            delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url])
+            delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+            delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url])
             client.disconnect(closeCode: 1001)
         case .error(let error):
             let nsError = error as NSError?
@@ -176,13 +175,13 @@ var READY_STATE = [
             if ((errorCode == 61 || errorCode == 57) && (errorCounter[url] ?? 0) % 2 == 0) {
                 let count = errorCounter[url] ?? 0
                 errorCounter[url] = count + 1
-                delegate?.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
-                delegate?.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": error?.localizedDescription as Any, "code": errorCode as Any]])
+                delegate.sendEvent(name: WSEvents.READY_STATE_EVENT.rawValue, result: ["url": url, "message": READY_STATE["CLOSED"]!])
+                delegate.sendEvent(name: WSEvents.CLOSE_EVENT.rawValue, result: ["url": url, "message": ["reason": error?.localizedDescription as Any, "code": errorCode as Any]])
             } else {
                 let errorDetails: [String: Any] = [
                     "message": nsError?.description,
                 ]
-                delegate?.sendEvent(name: WSEvents.ERROR_EVENT.rawValue, result: ["url": url, "message": ["error": errorDetails]])
+                delegate.sendEvent(name: WSEvents.ERROR_EVENT.rawValue, result: ["url": url, "message": ["error": errorDetails]])
             }
         case .viabilityChanged(let viable):
             print("Websocket viable \(viable)")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
this is the second part of the websocket crash. See: https://github.com/mattermost/mattermost-mobile/pull/9639

fix(ios): synchronize WebSocket dictionary access and prevent delegate use-after-free

Add a serial dispatch queue to protect the `webSockets` dictionary in WebSocketManager from concurrent access across URLSession delegate callbacks, main queue, and the RN bridge. All reads/writes are now wrapped in `queue.sync {}` with atomic remove-and-return in `invalidateClient` and atomic snapshot+removeAll in `invalidateContext` to eliminate TOCTOU races.

In WebSocketWrapper.didReceive, capture the weak `self.delegate` into a strong local at method entry so the delegate cannot deallocate mid-callback, preventing EXC_BAD_ACCESS.

Addresses Sentry issues MATTERMOST-MOBILE-IOS-XHW and MATTERMOST-MOBILE-IOS-YQG.


Once this is done, we'll need to update the dependencies on the app
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[MM-67999](https://mattermost.atlassian.net/browse/MM-67999)