### PR TITLE
fix(ios): make apply_patches.rb idempotent to avoid double-applying diffs

### DIFF
--- a/ios/patches/apply_patches.rb
+++ b/ios/patches/apply_patches.rb
@@ -20,6 +20,12 @@ module Pod
         # target file in the diff (every patch here touches a single file) and is
         # wrapped so any parsing failure falls through to the normal apply path —
         # it can only ADD a skip, never block a legitimate first application.
+        #
+        # The signature is the largest CONTIGUOUS block of added lines (in order,
+        # with original indentation preserved), not a single line: a lone line
+        # could coincidentally already exist elsewhere in the file and cause a
+        # false skip on a genuine first apply. An ordered multi-line block is a
+        # far stronger "already applied" signal.
         def patch_additions_present?(file, repo_root, directory_arg)
             diff = File.read(file)
             target_rel = diff[/^\+\+\+\sb\/(.+?)\s*$/, 1]
@@ -33,13 +39,27 @@ module Pod
             target = File.join(repo_root, directory_arg, stripped)
             return false unless File.exist?(target)
 
-            added = diff.each_line
-                        .select { |l| l.start_with?('+') && !l.start_with?('+++') }
-                        .map { |l| l[1..].to_s.strip }
-                        .reject(&:empty?)
-            return false if added.empty?
+            # Group added (`+`) lines into contiguous runs, preserving each line's
+            # original indentation (only the leading '+' marker is removed). A run
+            # is broken by any context/removed/hunk line.
+            runs = []
+            current = []
+            diff.each_line do |line|
+                chomped = line.chomp
+                if chomped.start_with?('+') && !chomped.start_with?('+++')
+                    current << chomped[1..].to_s
+                else
+                    runs << current unless current.empty?
+                    current = []
+                end
+            end
+            runs << current unless current.empty?
+            return false if runs.empty?
 
-            signature = added.max_by(&:length)
+            # Largest contiguous block (most lines) = strongest ordered anchor.
+            signature = runs.max_by(&:length).join("\n")
+            return false if signature.strip.empty?
+
             File.read(target).include?(signature)
         rescue StandardError => e
             Pod::UI.warn "Idempotency check skipped for #{file}: #{e}"

--- a/ios/patches/apply_patches.rb
+++ b/ios/patches/apply_patches.rb
@@ -7,6 +7,45 @@ module Pod
             return Dir["ios/patches/*.diff"]
         end
         
+        # Returns true if the patch's added lines are already present in the
+        # target file. `git apply --check` can report a patch as appliable even
+        # when it has already been applied, because an inserted hunk may re-match
+        # its own trailing context at a new offset (the Alamofire diff inserts a
+        # block that itself ends in `downloadRequest.updateDownloadProgress(...)`,
+        # which re-matches the hunk context). Applying a second time duplicates
+        # the inserted lines — e.g. a second `let allHeaders` — which Swift 6 /
+        # Xcode 26 reject as a hard "invalid redeclaration" error.
+        #
+        # This is a content-based idempotency guard. It only consults the FIRST
+        # target file in the diff (every patch here touches a single file) and is
+        # wrapped so any parsing failure falls through to the normal apply path —
+        # it can only ADD a skip, never block a legitimate first application.
+        def patch_additions_present?(file, repo_root, directory_arg)
+            diff = File.read(file)
+            target_rel = diff[/^\+\+\+\sb\/(.+?)\s*$/, 1]
+            return false unless target_rel
+
+            # `-p2` strips the 2 leading path components (e.g. "b/Pods/"); the
+            # remainder is resolved relative to --directory (the Pods dir).
+            stripped = target_rel.split('/')[2..]&.join('/')
+            return false if stripped.nil? || stripped.empty?
+
+            target = File.join(repo_root, directory_arg, stripped)
+            return false unless File.exist?(target)
+
+            added = diff.each_line
+                        .select { |l| l.start_with?('+') && !l.start_with?('+++') }
+                        .map { |l| l[1..].to_s.strip }
+                        .reject(&:empty?)
+            return false if added.empty?
+
+            signature = added.max_by(&:length)
+            File.read(target).include?(signature)
+        rescue StandardError => e
+            Pod::UI.warn "Idempotency check skipped for #{file}: #{e}"
+            false
+        end
+
         def apply_patch(file)
             repo_root = `git rev-parse --show-toplevel`.strip
             directory_arg = Dir.glob(Pathname(repo_root).join("**/**/Pods")).first.sub("#{repo_root}/", "")
@@ -22,6 +61,15 @@ module Pod
 
                 can_apply = system("git apply --check #{base_args}")
                 if can_apply
+                    # Guard against re-applying a patch whose additions are already
+                    # present (git can still report it appliable — see comment on
+                    # patch_additions_present?). Prevents duplicate declarations
+                    # that break the Swift 6 / Xcode 26 build.
+                    if patch_additions_present?(file, repo_root, directory_arg)
+                        Pod::UI.puts "Skipping #{file} (additions already present)"
+                        next
+                    end
+
                     did_apply = system("git apply #{base_args}")
                     if did_apply
                         Pod::UI.puts "Successfully applied #{file}"


### PR DESCRIPTION
## Summary

`ios/patches/apply_patches.rb` (invoked from the podspec `prepare_command`)
guards against re-applying a diff with `git apply --check --reverse`. That
check can miss an already-applied patch: an inserted hunk may re-match its
own trailing context at a new offset, so `git apply --check` still reports
the patch as appliable.

`Alamofire+5.11.2.diff` is a concrete case — the block it inserts ends in
`downloadRequest.updateDownloadProgress(...)`, which re-matches the hunk
context. Under some pod-install conditions the diff applies **twice**,
producing a duplicate `let allHeaders` declaration that **Swift 6 / Xcode 26
reject as a hard "invalid redeclaration" error**.

## Fix

Add a content-based idempotency guard. When `git apply --check` reports the
patch appliable, first check whether the patch's added lines are already
present in the target file; if so, skip applying.

- Only triggers in the double-apply case (git says appliable **and**
  additions already present). A pristine first application is unaffected.
- Wrapped in a `rescue` so any parsing failure falls through to the existing
  apply path — it can only *add* a skip, never block a legitimate apply.
- Consults the first target file in the diff (each diff here touches one
  file).

## Context / downstream

mattermost-mobile currently works around this in its `Podfile` `post_install`
by stripping the duplicate `let allHeaders` after the fact. Fixing it here
makes patch application idempotent for every consumer, so that downstream
workaround can be removed once a release with this lands is consumed
(mattermost-mobile PR #9804 / #9789).

## Verification

- `ruby -c ios/patches/apply_patches.rb` → Syntax OK.
- Logic reasoned through; a full end-to-end check is via a consumer's
  `pod install` + iOS build (Xcode 26 / Swift 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)