### PR TITLE
fix(android): eliminate OOM in response handling

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -286,8 +286,8 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
             // Stream-parse JSON token by token directly from the InputStream.
             // No intermediate String or StringBuilder — the Okio segment buffer
             // drains at token-read speed and peak heap is the WritableMap tree only.
-            try {
-                JsonReader(InputStreamReader(pushback, StandardCharsets.UTF_8)).use { reader ->
+            JsonReader(InputStreamReader(pushback, StandardCharsets.UTF_8)).use { reader ->
+                try {
                     when (reader.peek()) {
                         JsonToken.BEGIN_OBJECT -> map.putMap("data", reader.readWritableMap())
                         JsonToken.BEGIN_ARRAY -> map.putArray("data", reader.readWritableArray())
@@ -309,13 +309,14 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                         JsonToken.NULL -> { reader.nextNull(); map.putNull("data") }
                         else -> map.putString("data", "")
                     }
+                } catch (_: Exception) {
+                    map.putString("data", "")
+                } finally {
+                    // Drain any remaining bytes before the reader closes the stream so
+                    // OkHttp can reuse the connection and countingStream.count is accurate.
+                    val drainBuffer = ByteArray(64 * 1024)
+                    try { while (pushback.read(drainBuffer) != -1) { /* drain */ } } catch (_: Exception) { }
                 }
-            } catch (_: Exception) {
-                // Drain remaining bytes so OkHttp can reuse the connection and
-                // countingStream.count reflects the full wire size.
-                val drainBuffer = ByteArray(64 * 1024)
-                try { while (pushback.read(drainBuffer) != -1) { /* drain */ } } catch (_: Exception) { }
-                map.putString("data", "")
             }
         } else {
             // Non-JSON body — read into a string with a hard cap to prevent OOM.
@@ -324,7 +325,9 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
         }
 
         if (metadata != null) {
-            metrics.putDouble("compressedSize", metadata.compressedSize.toDouble())
+            val compressedSize = if (metadata.compressedSize >= 0) metadata.compressedSize
+                else header("Content-Length")?.toLongOrNull() ?: 0L
+            metrics.putDouble("compressedSize", compressedSize.toDouble())
             metrics.putDouble("size", countingStream.count.toDouble())
             metrics.putDouble("startTime", metadata.requestStartNanos.toDouble())
             metrics.putDouble("endTime", metadata.requestEndNanos.toDouble())

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -1,5 +1,7 @@
 package com.mattermost.networkclient
 
+import android.util.JsonReader
+import android.util.JsonToken
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
@@ -11,16 +13,25 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
 import org.json.JSONObject
-import org.json.JSONTokener
 import java.io.FilterInputStream
-import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.security.MessageDigest
+import java.io.PushbackInputStream
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 
 
 var Response.retriesExhausted: Boolean? by NetworkClient.RequestRetriesExhausted
+
+// Number of bytes to peek for JSON sniffing. Large enough to skip any leading
+// whitespace or a UTF-8 BOM before the first meaningful character.
+private const val SNIFF_BYTES = 1024
+
+// Maximum number of UTF-16 chars retained for non-JSON string bodies.
+// Each char occupies 2 bytes in heap, so this caps heap usage at ~1 MB.
+// Bodies beyond this limit are drained and discarded — they are not valid
+// API payloads the app can use through the JS bridge.
+private const val MAX_STRING_BODY_CHARS = 512 * 1024
 
 /**
  * Wraps an InputStream and counts the bytes read through it. Used to compute the
@@ -41,6 +52,175 @@ private class CountingInputStream(stream: InputStream) : FilterInputStream(strea
         if (n > 0) count += n
         return n
     }
+}
+
+/**
+ * Returns true when the MIME type string declares a JSON content type,
+ * meaning we can skip body sniffing entirely.
+ */
+internal fun isMimeTypeJson(mimeType: String): Boolean =
+    mimeType == "application/json" ||
+        (mimeType.startsWith("application/") && mimeType.endsWith("+json")) ||
+        mimeType == "text/json"
+
+/**
+ * Returns true when the raw JSON number token should be routed to a
+ * floating-point parse rather than a long parse. Covers decimal points
+ * and both exponent indicator characters.
+ */
+internal fun isJsonNumberFloat(raw: String): Boolean =
+    raw.contains('.') || raw.contains('e') || raw.contains('E')
+
+/**
+ * Strips a UTF-8 BOM (EF BB BF) from the head of [stream] if present,
+ * then returns the stream ready for downstream parsing. When no BOM is
+ * found every byte is pushed back so the stream is unmodified.
+ *
+ * Uses a 3-byte PushbackInputStream internally; the caller receives the
+ * pushback stream directly so no extra wrapping is needed.
+ */
+internal fun stripBom(stream: InputStream): PushbackInputStream {
+    val pushback = PushbackInputStream(stream, 3)
+    val bom = ByteArray(3)
+    val bomRead = pushback.read(bom, 0, 3)
+    if (bomRead > 0) {
+        val hasBom = bomRead == 3 &&
+            bom[0] == 0xEF.toByte() &&
+            bom[1] == 0xBB.toByte() &&
+            bom[2] == 0xBF.toByte()
+        if (!hasBom) pushback.unread(bom, 0, bomRead)
+    }
+    return pushback
+}
+
+/**
+ * Sniffs up to [SNIFF_BYTES] from [stream] to find the first non-whitespace,
+ * non-BOM byte without buffering the full body. Returns true when that byte
+ * is '{' or '[', indicating a JSON object or array.
+ *
+ * The BOM (if present) is consumed and discarded. All other sniff bytes are
+ * pushed back so the returned stream begins at the first meaningful byte
+ * (preceded by any non-BOM whitespace that was part of the sniff window).
+ */
+internal fun sniffIsJson(stream: InputStream): Pair<Boolean, PushbackInputStream> {
+    val pushback = PushbackInputStream(stream, SNIFF_BYTES)
+    val sniffBuf = ByteArray(SNIFF_BYTES)
+    val sniffRead = pushback.read(sniffBuf, 0, SNIFF_BYTES)
+
+    var scanStart = 0
+    if (sniffRead >= 3 &&
+        sniffBuf[0] == 0xEF.toByte() &&
+        sniffBuf[1] == 0xBB.toByte() &&
+        sniffBuf[2] == 0xBF.toByte()) {
+        scanStart = 3
+    }
+
+    var firstMeaningful: Byte = 0
+    for (i in scanStart until sniffRead) {
+        val b = sniffBuf[i]
+        if (b != ' '.code.toByte() &&
+            b != '\t'.code.toByte() &&
+            b != '\n'.code.toByte() &&
+            b != '\r'.code.toByte()) {
+            firstMeaningful = b
+            break
+        }
+    }
+
+    if (sniffRead > scanStart) {
+        pushback.unread(sniffBuf, scanStart, sniffRead - scanStart)
+    }
+
+    val isJson = firstMeaningful == '{'.code.toByte() || firstMeaningful == '['.code.toByte()
+    return Pair(isJson, pushback)
+}
+
+/**
+ * Reads at most MAX_STRING_BODY_CHARS from the stream into a String and then
+ * discards the remainder. Prevents unbounded heap allocation for non-JSON bodies.
+ */
+internal fun readCappedString(stream: InputStream): String {
+    val sb = StringBuilder()
+    val charBuffer = CharArray(64 * 1024)
+    val drainBuffer = ByteArray(64 * 1024)
+    var totalChars = 0
+    InputStreamReader(stream, StandardCharsets.UTF_8).use { reader ->
+        var read = reader.read(charBuffer)
+        while (read != -1) {
+            val toAppend = minOf(read, MAX_STRING_BODY_CHARS - totalChars)
+            if (toAppend > 0) sb.append(charBuffer, 0, toAppend)
+            totalChars += read
+            if (totalChars >= MAX_STRING_BODY_CHARS) {
+                // Drain remaining bytes via the raw stream to release Okio segments
+                // without accumulating any more data in heap.
+                while (stream.read(drainBuffer) != -1) { /* drain */ }
+                break
+            }
+            read = reader.read(charBuffer)
+        }
+    }
+    return sb.toString()
+}
+
+/**
+ * Recursively reads a JSON object from the JsonReader into a WritableMap.
+ */
+private fun JsonReader.readWritableMap(): WritableMap {
+    val map = Arguments.createMap()
+    beginObject()
+    while (hasNext()) {
+        val key = nextName()
+        when (peek()) {
+            JsonToken.BEGIN_OBJECT -> map.putMap(key, readWritableMap())
+            JsonToken.BEGIN_ARRAY -> map.putArray(key, readWritableArray())
+            JsonToken.STRING -> map.putString(key, nextString())
+            JsonToken.BOOLEAN -> map.putBoolean(key, nextBoolean())
+            JsonToken.NUMBER -> {
+                val raw = nextString()
+                if (isJsonNumberFloat(raw)) {
+                    map.putDouble(key, raw.toDouble())
+                } else {
+                    val l = raw.toLong()
+                    if (l in Int.MIN_VALUE..Int.MAX_VALUE) map.putInt(key, l.toInt())
+                    else map.putDouble(key, l.toDouble())
+                }
+            }
+            JsonToken.NULL -> { nextNull(); map.putNull(key) }
+            else -> skipValue()
+        }
+    }
+    endObject()
+    return map
+}
+
+/**
+ * Recursively reads a JSON array from the JsonReader into a WritableArray.
+ */
+private fun JsonReader.readWritableArray(): WritableArray {
+    val array = Arguments.createArray()
+    beginArray()
+    while (hasNext()) {
+        when (peek()) {
+            JsonToken.BEGIN_OBJECT -> array.pushMap(readWritableMap())
+            JsonToken.BEGIN_ARRAY -> array.pushArray(readWritableArray())
+            JsonToken.STRING -> array.pushString(nextString())
+            JsonToken.BOOLEAN -> array.pushBoolean(nextBoolean())
+            JsonToken.NUMBER -> {
+                val raw = nextString()
+                if (isJsonNumberFloat(raw)) {
+                    array.pushDouble(raw.toDouble())
+                } else {
+                    val l = raw.toLong()
+                    if (l in Int.MIN_VALUE..Int.MAX_VALUE) array.pushInt(l.toInt())
+                    else array.pushDouble(l.toDouble())
+                }
+            }
+            JsonToken.NULL -> { nextNull(); array.pushNull() }
+            else -> skipValue()
+        }
+    }
+    endArray()
+    return array
 }
 
 /**
@@ -79,48 +259,48 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
     map.putBoolean("ok", isSuccessful)
 
     body?.let { responseBody ->
-        // Stream-decode the body so peak memory is the resulting String (plus a small
-        // rolling char buffer), not the full body buffered in Okio segments first.
-        // CountingInputStream tracks the byte count for the size metric, which stays
-        // accurate when Content-Length is missing (chunked) or stale (compression).
         val countingStream = CountingInputStream(responseBody.source().inputStream())
-        val bodyString = InputStreamReader(countingStream, StandardCharsets.UTF_8).use { reader ->
-            val sb = StringBuilder()
-            val charBuffer = CharArray(64 * 1024)
-            var read = reader.read(charBuffer)
-            while (read != -1) {
-                sb.append(charBuffer, 0, read)
-                read = reader.read(charBuffer)
+
+        val mimeType = responseBody.contentType()?.let { "${it.type}/${it.subtype}" } ?: ""
+        val isJson: Boolean
+        val pushback: PushbackInputStream
+
+        if (isMimeTypeJson(mimeType)) {
+            isJson = true
+            pushback = stripBom(countingStream)
+        } else {
+            val (sniffed, sniffStream) = sniffIsJson(countingStream)
+            isJson = sniffed
+            pushback = sniffStream
+        }
+
+        if (isJson) {
+            // Stream-parse JSON token by token directly from the InputStream.
+            // No intermediate String or StringBuilder — the Okio segment buffer
+            // drains at token-read speed and peak heap is the WritableMap tree only.
+            try {
+                JsonReader(InputStreamReader(pushback, StandardCharsets.UTF_8)).use { reader ->
+                    when (reader.peek()) {
+                        JsonToken.BEGIN_OBJECT -> map.putMap("data", reader.readWritableMap())
+                        JsonToken.BEGIN_ARRAY -> map.putArray("data", reader.readWritableArray())
+                        else -> map.putString("data", "")
+                    }
+                }
+            } catch (_: Exception) {
+                map.putString("data", "")
             }
-            sb.toString()
+        } else {
+            // Non-JSON body — read into a string with a hard cap to prevent OOM.
+            // Responses beyond the cap are not valid API payloads the app can use.
+            map.putString("data", readCappedString(pushback))
         }
 
         if (metadata != null) {
-            val compressedSize = header("X-Compressed-Size")?.toDoubleOrNull() ?: header("Content-Length")?.toDoubleOrNull() ?: 0.0
-            val startTime = header("X-Start-Time")?.toDoubleOrNull() ?: 0.0
-            val endTime = header("X-End-Time")?.toDoubleOrNull() ?: 0.0
-            val mbps = header("X-Speed-Mbps")?.toDoubleOrNull() ?: 0.0
-            metrics.putDouble("compressedSize", compressedSize)
+            metrics.putDouble("compressedSize", metadata.compressedSize.toDouble())
             metrics.putDouble("size", countingStream.count.toDouble())
-            metrics.putDouble("startTime", startTime)
-            metrics.putDouble("endTime", endTime)
-            metrics.putDouble("speedInMbps", mbps)
-        }
-
-        try {
-            when (val json = JSONTokener(bodyString).nextValue()) {
-                is JSONArray -> {
-                    map.putArray("data", json.toWritableArray())
-                }
-                is JSONObject -> {
-                    map.putMap("data", json.toWritableMap())
-                }
-                else -> {
-                    map.putString("data", bodyString)
-                }
-            }
-        } catch (_: Exception) {
-            map.putString("data", bodyString)
+            metrics.putDouble("startTime", metadata.requestStartNanos.toDouble())
+            metrics.putDouble("endTime", metadata.requestEndNanos.toDouble())
+            metrics.putDouble("speedInMbps", metadata.getSpeedInMbps())
         }
     }
 

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -82,7 +82,12 @@ internal fun isJsonNumberFloat(raw: String): Boolean =
 internal fun stripBom(stream: InputStream): PushbackInputStream {
     val pushback = PushbackInputStream(stream, 3)
     val bom = ByteArray(3)
-    val bomRead = pushback.read(bom, 0, 3)
+    var bomRead = 0
+    while (bomRead < 3) {
+        val n = pushback.read(bom, bomRead, 3 - bomRead)
+        if (n == -1) break
+        bomRead += n
+    }
     if (bomRead > 0) {
         val hasBom = bomRead == 3 &&
             bom[0] == 0xEF.toByte() &&
@@ -103,20 +108,17 @@ internal fun stripBom(stream: InputStream): PushbackInputStream {
  * (preceded by any non-BOM whitespace that was part of the sniff window).
  */
 internal fun sniffIsJson(stream: InputStream): Pair<Boolean, PushbackInputStream> {
-    val pushback = PushbackInputStream(stream, SNIFF_BYTES)
+    val pushback = PushbackInputStream(stripBom(stream), SNIFF_BYTES)
     val sniffBuf = ByteArray(SNIFF_BYTES)
-    val sniffRead = pushback.read(sniffBuf, 0, SNIFF_BYTES)
-
-    var scanStart = 0
-    if (sniffRead >= 3 &&
-        sniffBuf[0] == 0xEF.toByte() &&
-        sniffBuf[1] == 0xBB.toByte() &&
-        sniffBuf[2] == 0xBF.toByte()) {
-        scanStart = 3
+    var sniffRead = 0
+    while (sniffRead < SNIFF_BYTES) {
+        val n = pushback.read(sniffBuf, sniffRead, SNIFF_BYTES - sniffRead)
+        if (n == -1) break
+        sniffRead += n
     }
 
     var firstMeaningful: Byte = 0
-    for (i in scanStart until sniffRead) {
+    for (i in 0 until sniffRead) {
         val b = sniffBuf[i]
         if (b != ' '.code.toByte() &&
             b != '\t'.code.toByte() &&
@@ -127,8 +129,8 @@ internal fun sniffIsJson(stream: InputStream): Pair<Boolean, PushbackInputStream
         }
     }
 
-    if (sniffRead > scanStart) {
-        pushback.unread(sniffBuf, scanStart, sniffRead - scanStart)
+    if (sniffRead > 0) {
+        pushback.unread(sniffBuf, 0, sniffRead)
     }
 
     val isJson = firstMeaningful == '{'.code.toByte() || firstMeaningful == '['.code.toByte()

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -180,11 +180,15 @@ private fun JsonReader.readWritableMap(): WritableMap {
             JsonToken.NUMBER -> {
                 val raw = nextString()
                 if (isJsonNumberFloat(raw)) {
-                    raw.toDoubleOrNull()?.let { map.putDouble(key, it) } ?: map.putString(key, raw)
+                    val d = raw.toDoubleOrNull()
+                    if (d != null && d.isFinite()) map.putDouble(key, d) else map.putString(key, raw)
                 } else {
                     val l = raw.toLongOrNull()
                     when {
-                        l == null -> raw.toDoubleOrNull()?.let { map.putDouble(key, it) } ?: map.putString(key, raw)
+                        l == null -> {
+                            val d = raw.toDoubleOrNull()
+                            if (d != null && d.isFinite()) map.putDouble(key, d) else map.putString(key, raw)
+                        }
                         l in Int.MIN_VALUE..Int.MAX_VALUE -> map.putInt(key, l.toInt())
                         else -> map.putDouble(key, l.toDouble())
                     }
@@ -213,11 +217,15 @@ private fun JsonReader.readWritableArray(): WritableArray {
             JsonToken.NUMBER -> {
                 val raw = nextString()
                 if (isJsonNumberFloat(raw)) {
-                    raw.toDoubleOrNull()?.let { array.pushDouble(it) } ?: array.pushString(raw)
+                    val d = raw.toDoubleOrNull()
+                    if (d != null && d.isFinite()) array.pushDouble(d) else array.pushString(raw)
                 } else {
                     val l = raw.toLongOrNull()
                     when {
-                        l == null -> raw.toDoubleOrNull()?.let { array.pushDouble(it) } ?: array.pushString(raw)
+                        l == null -> {
+                            val d = raw.toDoubleOrNull()
+                            if (d != null && d.isFinite()) array.pushDouble(d) else array.pushString(raw)
+                        }
                         l in Int.MIN_VALUE..Int.MAX_VALUE -> array.pushInt(l.toInt())
                         else -> array.pushDouble(l.toDouble())
                     }
@@ -296,11 +304,15 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                         JsonToken.NUMBER -> {
                             val raw = reader.nextString()
                             if (isJsonNumberFloat(raw)) {
-                                raw.toDoubleOrNull()?.let { map.putDouble("data", it) } ?: map.putString("data", raw)
+                                val d = raw.toDoubleOrNull()
+                                if (d != null && d.isFinite()) map.putDouble("data", d) else map.putString("data", raw)
                             } else {
                                 val l = raw.toLongOrNull()
                                 when {
-                                    l == null -> raw.toDoubleOrNull()?.let { map.putDouble("data", it) } ?: map.putString("data", raw)
+                                    l == null -> {
+                                        val d = raw.toDoubleOrNull()
+                                        if (d != null && d.isFinite()) map.putDouble("data", d) else map.putString("data", raw)
+                                    }
                                     l in Int.MIN_VALUE..Int.MAX_VALUE -> map.putInt("data", l.toInt())
                                     else -> map.putDouble("data", l.toDouble())
                                 }

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -310,7 +310,7 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                         else -> map.putString("data", "")
                     }
                 } catch (_: Exception) {
-                    map.putString("data", "")
+                    map.putNull("data")
                 } finally {
                     // Drain any remaining bytes before the reader closes the stream so
                     // OkHttp can reuse the connection and countingStream.count is accurate.

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -180,11 +180,14 @@ private fun JsonReader.readWritableMap(): WritableMap {
             JsonToken.NUMBER -> {
                 val raw = nextString()
                 if (isJsonNumberFloat(raw)) {
-                    map.putDouble(key, raw.toDouble())
+                    raw.toDoubleOrNull()?.let { map.putDouble(key, it) } ?: map.putString(key, raw)
                 } else {
-                    val l = raw.toLong()
-                    if (l in Int.MIN_VALUE..Int.MAX_VALUE) map.putInt(key, l.toInt())
-                    else map.putDouble(key, l.toDouble())
+                    val l = raw.toLongOrNull()
+                    when {
+                        l == null -> raw.toDoubleOrNull()?.let { map.putDouble(key, it) } ?: map.putString(key, raw)
+                        l in Int.MIN_VALUE..Int.MAX_VALUE -> map.putInt(key, l.toInt())
+                        else -> map.putDouble(key, l.toDouble())
+                    }
                 }
             }
             JsonToken.NULL -> { nextNull(); map.putNull(key) }
@@ -210,11 +213,14 @@ private fun JsonReader.readWritableArray(): WritableArray {
             JsonToken.NUMBER -> {
                 val raw = nextString()
                 if (isJsonNumberFloat(raw)) {
-                    array.pushDouble(raw.toDouble())
+                    raw.toDoubleOrNull()?.let { array.pushDouble(it) } ?: array.pushString(raw)
                 } else {
-                    val l = raw.toLong()
-                    if (l in Int.MIN_VALUE..Int.MAX_VALUE) array.pushInt(l.toInt())
-                    else array.pushDouble(l.toDouble())
+                    val l = raw.toLongOrNull()
+                    when {
+                        l == null -> raw.toDoubleOrNull()?.let { array.pushDouble(it) } ?: array.pushString(raw)
+                        l in Int.MIN_VALUE..Int.MAX_VALUE -> array.pushInt(l.toInt())
+                        else -> array.pushDouble(l.toDouble())
+                    }
                 }
             }
             JsonToken.NULL -> { nextNull(); array.pushNull() }
@@ -290,11 +296,14 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                         JsonToken.NUMBER -> {
                             val raw = reader.nextString()
                             if (isJsonNumberFloat(raw)) {
-                                map.putDouble("data", raw.toDouble())
+                                raw.toDoubleOrNull()?.let { map.putDouble("data", it) } ?: map.putString("data", raw)
                             } else {
-                                val l = raw.toLong()
-                                if (l in Int.MIN_VALUE..Int.MAX_VALUE) map.putInt("data", l.toInt())
-                                else map.putDouble("data", l.toDouble())
+                                val l = raw.toLongOrNull()
+                                when {
+                                    l == null -> raw.toDoubleOrNull()?.let { map.putDouble("data", it) } ?: map.putString("data", raw)
+                                    l in Int.MIN_VALUE..Int.MAX_VALUE -> map.putInt("data", l.toInt())
+                                    else -> map.putDouble("data", l.toDouble())
+                                }
                             }
                         }
                         JsonToken.NULL -> { reader.nextNull(); map.putNull("data") }

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -285,6 +285,19 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                     when (reader.peek()) {
                         JsonToken.BEGIN_OBJECT -> map.putMap("data", reader.readWritableMap())
                         JsonToken.BEGIN_ARRAY -> map.putArray("data", reader.readWritableArray())
+                        JsonToken.STRING -> map.putString("data", reader.nextString())
+                        JsonToken.BOOLEAN -> map.putBoolean("data", reader.nextBoolean())
+                        JsonToken.NUMBER -> {
+                            val raw = reader.nextString()
+                            if (isJsonNumberFloat(raw)) {
+                                map.putDouble("data", raw.toDouble())
+                            } else {
+                                val l = raw.toLong()
+                                if (l in Int.MIN_VALUE..Int.MAX_VALUE) map.putInt("data", l.toInt())
+                                else map.putDouble("data", l.toDouble())
+                            }
+                        }
+                        JsonToken.NULL -> { reader.nextNull(); map.putNull("data") }
                         else -> map.putString("data", "")
                     }
                 }

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -144,7 +144,6 @@ internal fun sniffIsJson(stream: InputStream): Pair<Boolean, PushbackInputStream
 internal fun readCappedString(stream: InputStream): String {
     val sb = StringBuilder()
     val charBuffer = CharArray(64 * 1024)
-    val drainBuffer = ByteArray(64 * 1024)
     var totalChars = 0
     InputStreamReader(stream, StandardCharsets.UTF_8).use { reader ->
         var read = reader.read(charBuffer)
@@ -155,6 +154,7 @@ internal fun readCappedString(stream: InputStream): String {
             if (totalChars >= MAX_STRING_BODY_CHARS) {
                 // Drain remaining bytes via the raw stream to release Okio segments
                 // without accumulating any more data in heap.
+                val drainBuffer = ByteArray(64 * 1024)
                 while (stream.read(drainBuffer) != -1) { /* drain */ }
                 break
             }
@@ -326,8 +326,10 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                 } finally {
                     // Drain any remaining bytes before the reader closes the stream so
                     // OkHttp can reuse the connection and countingStream.count is accurate.
-                    val drainBuffer = ByteArray(64 * 1024)
-                    try { while (pushback.read(drainBuffer) != -1) { /* drain */ } } catch (_: Exception) { }
+                    try {
+                        val drainBuffer = ByteArray(64 * 1024)
+                        while (pushback.read(drainBuffer) != -1) { /* drain */ }
+                    } catch (_: Exception) { }
                 }
             }
         } else {

--- a/android/src/main/java/com/mattermost/networkclient/Extensions.kt
+++ b/android/src/main/java/com/mattermost/networkclient/Extensions.kt
@@ -311,6 +311,10 @@ fun Response.toWritableMap(metadata: RequestMetadata?): WritableMap {
                     }
                 }
             } catch (_: Exception) {
+                // Drain remaining bytes so OkHttp can reuse the connection and
+                // countingStream.count reflects the full wire size.
+                val drainBuffer = ByteArray(64 * 1024)
+                try { while (pushback.read(drainBuffer) != -1) { /* drain */ } } catch (_: Exception) { }
                 map.putString("data", "")
             }
         } else {

--- a/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
+++ b/android/src/main/java/com/mattermost/networkclient/NetworkClient.kt
@@ -100,7 +100,7 @@ internal class NetworkClient(private val context: Context, private val baseUrl: 
         builder.addNetworkInterceptor(BrotliInterceptor)
 
         if (shouldCollectMetrics) {
-            builder.addNetworkInterceptor(CompressedResponseSizeInterceptor())
+            builder.addNetworkInterceptor(CompressedResponseSizeInterceptor(metricsEventFactory))
         }
 
         if (baseUrl == null) {

--- a/android/src/main/java/com/mattermost/networkclient/helpers/CountingResponseBody.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/CountingResponseBody.kt
@@ -17,8 +17,10 @@ class CountingResponseBody(
     override fun contentType(): MediaType? = delegate.contentType()
     override fun contentLength(): Long = delegate.contentLength()
 
-    override fun source(): BufferedSource {
-        val countingSource = object : ForwardingSource(delegate.source()) {
+    override fun source(): BufferedSource = bufferedSource
+
+    private val bufferedSource: BufferedSource by lazy {
+        object : ForwardingSource(delegate.source()) {
             override fun read(sink: Buffer, byteCount: Long): Long {
                 val read = super.read(sink, byteCount)
                 if (read != -1L) {
@@ -33,8 +35,7 @@ class CountingResponseBody(
                 notifyComplete()
                 super.close()
             }
-        }
-        return countingSource.buffer()
+        }.buffer()
     }
 
     private fun notifyComplete() {

--- a/android/src/main/java/com/mattermost/networkclient/helpers/CountingResponseBody.kt
+++ b/android/src/main/java/com/mattermost/networkclient/helpers/CountingResponseBody.kt
@@ -1,0 +1,46 @@
+package com.mattermost.networkclient.helpers
+
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.buffer
+
+class CountingResponseBody(
+    private val delegate: ResponseBody,
+    private val onComplete: (Long) -> Unit,
+) : ResponseBody() {
+    private var totalBytesRead = 0L
+    private var completed = false
+
+    override fun contentType(): MediaType? = delegate.contentType()
+    override fun contentLength(): Long = delegate.contentLength()
+
+    override fun source(): BufferedSource {
+        val countingSource = object : ForwardingSource(delegate.source()) {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                val read = super.read(sink, byteCount)
+                if (read != -1L) {
+                    totalBytesRead += read
+                } else {
+                    notifyComplete()
+                }
+                return read
+            }
+
+            override fun close() {
+                notifyComplete()
+                super.close()
+            }
+        }
+        return countingSource.buffer()
+    }
+
+    private fun notifyComplete() {
+        if (!completed) {
+            completed = true
+            onComplete(totalBytesRead)
+        }
+    }
+}

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -12,14 +12,15 @@ class CompressedResponseSizeInterceptor(private val metricsEventFactory: Metrics
 
         val body = response.body ?: return response
         val metadata = metricsEventFactory?.getMetadata(chain.call())
-        val expectedSize = response.header("Content-Length")?.toLongOrNull()
-            ?: response.header("content-length")?.toLongOrNull()
+            ?: return response  // no metrics tracking for this call, skip wrapping
 
-        metadata?.requestStartNanos = startTime
+        val expectedSize = response.header("Content-Length")?.toLongOrNull()
+
+        metadata.requestStartNanos = startTime
 
         val countingBody = CountingResponseBody(body) { bytesRead ->
-            metadata?.compressedSize = expectedSize ?: bytesRead
-            metadata?.requestEndNanos = System.nanoTime()
+            metadata.compressedSize = expectedSize ?: bytesRead
+            metadata.requestEndNanos = System.nanoTime()
         }
 
         return response.newBuilder().body(countingBody).build()

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -9,25 +9,15 @@ class CompressedResponseSizeInterceptor(private val metricsEventFactory: Metrics
     override fun intercept(chain: Interceptor.Chain): Response {
         val startTime = System.nanoTime()
         val response = chain.proceed(chain.request())
-        val endTime = System.nanoTime()
-
-        val compressedSize = response.header("Content-Length")?.toLongOrNull()
-            ?: response.header("content-length")?.toLongOrNull()
-
-        if (compressedSize != null) {
-            val metadata = metricsEventFactory?.getMetadata(chain.call())
-            metadata?.compressedSize = compressedSize
-            metadata?.requestStartNanos = startTime
-            metadata?.requestEndNanos = endTime
-            return response
-        }
 
         val body = response.body ?: return response
         val call = chain.call()
+        val expectedSize = response.header("Content-Length")?.toLongOrNull()
+            ?: response.header("content-length")?.toLongOrNull()
 
         val countingBody = CountingResponseBody(body) { bytesRead ->
             val metadata = metricsEventFactory?.getMetadata(call)
-            metadata?.compressedSize = bytesRead
+            metadata?.compressedSize = expectedSize ?: bytesRead
             metadata?.requestStartNanos = startTime
             metadata?.requestEndNanos = System.nanoTime()
         }

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -1,46 +1,37 @@
 package com.mattermost.networkclient.interceptors
 
+import com.mattermost.networkclient.helpers.CountingResponseBody
+import com.mattermost.networkclient.metrics.MetricsEventFactory
 import okhttp3.Interceptor
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
-import java.util.Locale
 
-class CompressedResponseSizeInterceptor: Interceptor {
+class CompressedResponseSizeInterceptor(private val metricsEventFactory: MetricsEventFactory?) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        // Record the start time
         val startTime = System.nanoTime()
-
         val response = chain.proceed(chain.request())
-
-        // Record the end time
         val endTime = System.nanoTime()
 
-        // Calculate elapsed time in seconds
-        val elapsedTimeSeconds = (endTime - startTime) / 1_000_000_000.0
+        val compressedSize = response.header("Content-Length")?.toLongOrNull()
+            ?: response.header("content-length")?.toLongOrNull()
 
-        val modifiedResponse = response.newBuilder()
-
-        var compressedSize = response.header("Content-Length")?.toLongOrNull() ?: response.header("content-length")?.toLongOrNull()
-        if (compressedSize == null) {
-            val rawBytes = response.body?.byteStream()?.readBytes()
-            compressedSize = rawBytes?.size?.toLong() ?: -1L
-            modifiedResponse.body((rawBytes ?: ByteArray(0)).toResponseBody(response.body?.contentType()))
+        if (compressedSize != null) {
+            val metadata = metricsEventFactory?.getMetadata(chain.call())
+            metadata?.compressedSize = compressedSize
+            metadata?.requestStartNanos = startTime
+            metadata?.requestEndNanos = endTime
+            return response
         }
 
-        // Calculate speed in Mbps
-        val speedMbps = if (elapsedTimeSeconds > 0 && compressedSize > 0) {
-            (compressedSize * 8 / elapsedTimeSeconds) / 1_000_000.0
-        } else {
-            0.0
+        val body = response.body ?: return response
+        val call = chain.call()
+
+        val countingBody = CountingResponseBody(body) { bytesRead ->
+            val metadata = metricsEventFactory?.getMetadata(call)
+            metadata?.compressedSize = bytesRead
+            metadata?.requestStartNanos = startTime
+            metadata?.requestEndNanos = System.nanoTime()
         }
 
-        return modifiedResponse
-            .header("X-Compressed-Size", compressedSize.toString())
-            .header("X-Start-Time", startTime.toString())
-            .header("X-End-Time", endTime.toString())
-            // Use Locale.US to ensure ASCII digits in header values.
-            // System locale formatting (e.g. Arabic) produces non-ASCII digits that OkHttp rejects.
-            .header("X-Speed-Mbps", String.format(Locale.US, "%.4f", speedMbps))
-            .build()
+        return response.newBuilder().body(countingBody).build()
     }
 }

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -15,9 +15,10 @@ class CompressedResponseSizeInterceptor(private val metricsEventFactory: Metrics
         val expectedSize = response.header("Content-Length")?.toLongOrNull()
             ?: response.header("content-length")?.toLongOrNull()
 
+        metadata?.requestStartNanos = startTime
+
         val countingBody = CountingResponseBody(body) { bytesRead ->
             metadata?.compressedSize = expectedSize ?: bytesRead
-            metadata?.requestStartNanos = startTime
             metadata?.requestEndNanos = System.nanoTime()
         }
 

--- a/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
+++ b/android/src/main/java/com/mattermost/networkclient/interceptors/CompressedResponseSizeInterceptor.kt
@@ -11,12 +11,11 @@ class CompressedResponseSizeInterceptor(private val metricsEventFactory: Metrics
         val response = chain.proceed(chain.request())
 
         val body = response.body ?: return response
-        val call = chain.call()
+        val metadata = metricsEventFactory?.getMetadata(chain.call())
         val expectedSize = response.header("Content-Length")?.toLongOrNull()
             ?: response.header("content-length")?.toLongOrNull()
 
         val countingBody = CountingResponseBody(body) { bytesRead ->
-            val metadata = metricsEventFactory?.getMetadata(call)
             metadata?.compressedSize = expectedSize ?: bytesRead
             metadata?.requestStartNanos = startTime
             metadata?.requestEndNanos = System.nanoTime()

--- a/android/src/main/java/com/mattermost/networkclient/metrics/MetricsEventFactory.kt
+++ b/android/src/main/java/com/mattermost/networkclient/metrics/MetricsEventFactory.kt
@@ -2,9 +2,10 @@ package com.mattermost.networkclient.metrics
 
 import okhttp3.Call
 import okhttp3.EventListener
+import java.util.concurrent.ConcurrentHashMap
 
 class MetricsEventFactory : EventListener.Factory {
-    private val metadataMap = mutableMapOf<Call, RequestMetadata>()
+    private val metadataMap = ConcurrentHashMap<Call, RequestMetadata>()
 
     override fun create(call: Call): EventListener {
         val metadata = RequestMetadata()

--- a/android/src/main/java/com/mattermost/networkclient/metrics/MetricsEventListener.kt
+++ b/android/src/main/java/com/mattermost/networkclient/metrics/MetricsEventListener.kt
@@ -64,8 +64,14 @@ class MetricsEventListener(
         }
     }
 
+    override fun callEnd(call: Call) {
+        super.callEnd(call)
+        factory.removeMetadata(call)
+    }
+
     override fun callFailed(call: Call, ioe: IOException) {
         super.callFailed(call, ioe)
+        factory.removeMetadata(call)
     }
 
     override fun canceled(call: Call) {

--- a/android/src/main/java/com/mattermost/networkclient/metrics/RequestMetadata.kt
+++ b/android/src/main/java/com/mattermost/networkclient/metrics/RequestMetadata.kt
@@ -11,8 +11,17 @@ data class RequestMetadata(
     var sslVersion: String? = null,
     var sslCipher: String? = null,
     var httpVersion: String? = null,
-    var networkType: String? = null
+    var networkType: String? = null,
+    var compressedSize: Long = -1L,
+    var requestStartNanos: Long = 0,
+    var requestEndNanos: Long = 0,
 ) {
     fun getLatency() = TimeUnit.NANOSECONDS.toMillis(responseStartNanos - callStartNanos)
     fun getConnectionTime() = TimeUnit.NANOSECONDS.toMillis(connectEndNanos - connectStartNanos)
+    fun getSpeedInMbps(): Double {
+        val elapsedSeconds = (requestEndNanos - requestStartNanos) / 1_000_000_000.0
+        return if (elapsedSeconds > 0 && compressedSize > 0) {
+            (compressedSize * 8 / elapsedSeconds) / 1_000_000.0
+        } else 0.0
+    }
 }

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
@@ -34,8 +34,10 @@ class CountingResponseBody(
     override fun contentType(): MediaType? = delegate.contentType()
     override fun contentLength(): Long = delegate.contentLength()
 
-    override fun source(): BufferedSource {
-        val countingSource = object : ForwardingSource(delegate.source()) {
+    override fun source(): BufferedSource = bufferedSource
+
+    private val bufferedSource: BufferedSource by lazy {
+        object : ForwardingSource(delegate.source()) {
             override fun read(sink: Buffer, byteCount: Long): Long {
                 val read = super.read(sink, byteCount)
                 if (read != -1L) {
@@ -50,8 +52,7 @@ class CountingResponseBody(
                 notifyComplete()
                 super.close()
             }
-        }
-        return countingSource.buffer()
+        }.buffer()
     }
 
     private fun notifyComplete() {

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
@@ -149,7 +149,7 @@ class CompressedResponseSizeInterceptorTest {
     }
 
     /**
-     * Streams a 512 MB synthetic response through CountingResponseBody using a
+     * Streams a 64 MB synthetic response through CountingResponseBody using a
      * on-the-fly source that never allocates more than one 64 KB chunk at a time.
      * Peak heap is ~64 KB regardless of total size — this test proves no OOM occurs
      * and that the byte count is exact.

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
@@ -1,176 +1,316 @@
 package com.mattermost.networkclient
 
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okhttp3.Interceptor
-import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
-import org.junit.Assert
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.Locale
+import java.util.concurrent.atomic.AtomicLong
 
-/**
- * Standalone test for CompressedResponseSizeInterceptor locale behavior.
- *
- * Reproduces MATTERMOST-MOBILE-ANDROID-AZ02: on Arabic-locale devices,
- * String.format() produces Arabic-Indic digits (U+0660 range) in the
- * X-Speed-Mbps header, which OkHttp rejects as invalid header characters.
- */
+// ---------------------------------------------------------------------------
+// Inline copy of CountingResponseBody (no Android deps in test-runner)
+// ---------------------------------------------------------------------------
+
+class CountingResponseBody(
+    private val delegate: ResponseBody,
+    private val onComplete: (Long) -> Unit,
+) : ResponseBody() {
+    private var totalBytesRead = 0L
+    private var completed = false
+
+    override fun contentType(): MediaType? = delegate.contentType()
+    override fun contentLength(): Long = delegate.contentLength()
+
+    override fun source(): BufferedSource {
+        val countingSource = object : ForwardingSource(delegate.source()) {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                val read = super.read(sink, byteCount)
+                if (read != -1L) {
+                    totalBytesRead += read
+                } else {
+                    notifyComplete()
+                }
+                return read
+            }
+
+            override fun close() {
+                notifyComplete()
+                super.close()
+            }
+        }
+        return countingSource.buffer()
+    }
+
+    private fun notifyComplete() {
+        if (!completed) {
+            completed = true
+            onComplete(totalBytesRead)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interceptor that mirrors CompressedResponseSizeInterceptor logic,
+// writing results into a shared AtomicLong instead of RequestMetadata
+// (no Android deps in test-runner).
+// ---------------------------------------------------------------------------
+
+class TestCompressedResponseSizeInterceptor(
+    private val compressedSizeOut: AtomicLong,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+
+        val contentLength = response.header("Content-Length")?.toLongOrNull()
+            ?: response.header("content-length")?.toLongOrNull()
+
+        if (contentLength != null) {
+            compressedSizeOut.set(contentLength)
+            return response
+        }
+
+        val body = response.body ?: return response
+
+        val countingBody = CountingResponseBody(body) { bytesRead ->
+            compressedSizeOut.set(bytesRead)
+        }
+        return response.newBuilder().body(countingBody).build()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 class CompressedResponseSizeInterceptorTest {
 
-    companion object {
-        /**
-         * Lock to prevent parallel tests from racing on Locale.setDefault().
-         * JVM locale is global state — concurrent mutation causes flaky tests.
-         */
-        private val LOCALE_LOCK = Any()
+    // --- CountingResponseBody unit tests ------------------------------------
+
+    @Test
+    fun countingBody_reportsCorrectSizeAtEof() {
+        val payload = "Hello, World!".toByteArray()
+        val delegate = payload.toResponseBody("text/plain".toMediaType())
+
+        var reported = -1L
+        val body = CountingResponseBody(delegate) { reported = it }
+
+        body.source().use { src ->
+            val sink = Buffer()
+            while (src.read(sink, 8192) != -1L) { /* drain */ }
+        }
+
+        assertEquals(payload.size.toLong(), reported)
+    }
+
+    @Test
+    fun countingBody_reportsOnCloseBeforeEof() {
+        val payload = ByteArray(1024) { it.toByte() }
+        val delegate = payload.toResponseBody("application/octet-stream".toMediaType())
+
+        var reported = -1L
+        val body = CountingResponseBody(delegate) { reported = it }
+
+        body.source().use { src ->
+            val sink = Buffer()
+            // Read only half then close — close() must still fire onComplete
+            src.read(sink, 512)
+        }
+
+        assertTrue("onComplete should have fired on early close", reported >= 0)
+        assertTrue("reported count should be <= total", reported <= payload.size.toLong())
+    }
+
+    @Test
+    fun countingBody_onCompleteFiresExactlyOnce() {
+        val payload = "data".toByteArray()
+        val delegate = payload.toResponseBody("text/plain".toMediaType())
+
+        var callCount = 0
+        val body = CountingResponseBody(delegate) { callCount++ }
+
+        body.source().use { src ->
+            val sink = Buffer()
+            // Read to EOF (fires onComplete via read returning -1)…
+            while (src.read(sink, 8192) != -1L) { /* drain */ }
+            // …then close() runs — must NOT fire again
+        }
+
+        assertEquals("onComplete must fire exactly once", 1, callCount)
     }
 
     /**
-     * Interceptor using the BROKEN locale-dependent formatting.
-     * This is what the code did before the fix.
+     * Streams a 512 MB synthetic response through CountingResponseBody using a
+     * on-the-fly source that never allocates more than one 64 KB chunk at a time.
+     * Peak heap is ~64 KB regardless of total size — this test proves no OOM occurs
+     * and that the byte count is exact.
      */
-    class BrokenInterceptor : Interceptor {
-        override fun intercept(chain: Interceptor.Chain): Response {
-            val startTime = System.nanoTime()
-            val response = chain.proceed(chain.request())
-            val endTime = System.nanoTime()
-            val elapsedTimeSeconds = (endTime - startTime) / 1_000_000_000.0
-            val compressedSize = response.header("Content-Length")?.toLongOrNull() ?: 0L
-            val speedMbps = if (elapsedTimeSeconds > 0 && compressedSize > 0) {
-                (compressedSize * 8 / elapsedTimeSeconds) / 1_000_000.0
-            } else {
-                0.0
-            }
-            return response.newBuilder()
-                .header("X-Speed-Mbps", "%.4f".format(speedMbps)) // locale-dependent!
-                .build()
-        }
-    }
-
-    /**
-     * Interceptor using the FIXED locale-independent formatting.
-     */
-    class FixedInterceptor : Interceptor {
-        override fun intercept(chain: Interceptor.Chain): Response {
-            val startTime = System.nanoTime()
-            val response = chain.proceed(chain.request())
-            val endTime = System.nanoTime()
-            val elapsedTimeSeconds = (endTime - startTime) / 1_000_000_000.0
-            val compressedSize = response.header("Content-Length")?.toLongOrNull() ?: 0L
-            val speedMbps = if (elapsedTimeSeconds > 0 && compressedSize > 0) {
-                (compressedSize * 8 / elapsedTimeSeconds) / 1_000_000.0
-            } else {
-                0.0
-            }
-            return response.newBuilder()
-                .header("X-Speed-Mbps", String.format(Locale.US, "%.4f", speedMbps))
-                .build()
-        }
-    }
-
     @Test
-    fun brokenInterceptor_failsWithArabicLocale() {
-        synchronized(LOCALE_LOCK) {
-            val originalLocale = Locale.getDefault()
-            try {
-                // Set Arabic locale — causes String.format to use Arabic-Indic digits
-                Locale.setDefault(Locale("ar"))
+    fun countingBody_512mb_noOom() {
+        val chunkSize = 64 * 1024
+        val totalBytes = 512L * 1024 * 1024 // 512 MB
+        val chunk = ByteArray(chunkSize) { 0xAB.toByte() }
 
-                MockWebServer().use { server ->
-                    server.enqueue(MockResponse()
-                        .setBody("hello")
-                        .setHeader("Content-Length", "5"))
-                    server.start()
-
-                    val client = OkHttpClient.Builder()
-                        .addInterceptor(BrokenInterceptor())
-                        .build()
-
-                    val request = Request.Builder()
-                        .url(server.url("/test"))
-                        .build()
-
-                    // The broken interceptor produces Arabic-Indic digits in the header value.
-                    // OkHttp's header validation rejects non-ASCII characters.
-                    try {
-                        client.newCall(request).execute().use { /* auto-close */ }
-                        Assert.fail("Expected IllegalArgumentException from OkHttp header validation")
-                    } catch (e: IllegalArgumentException) {
-                        Assert.assertTrue(
-                            "Expected error about unexpected char in header value",
-                            e.message?.contains("Unexpected char") == true
-                        )
-                    }
+        val delegate = object : ResponseBody() {
+            private val src: BufferedSource = object : ForwardingSource(Buffer()) {
+                private var remaining = totalBytes
+                override fun read(sink: Buffer, byteCount: Long): Long {
+                    if (remaining <= 0L) return -1L
+                    val toWrite = minOf(byteCount, remaining, chunkSize.toLong())
+                    sink.write(chunk, 0, toWrite.toInt())
+                    remaining -= toWrite
+                    return toWrite
                 }
-            } finally {
-                Locale.setDefault(originalLocale)
+            }.buffer()
+
+            override fun contentType() = "application/octet-stream".toMediaType()
+            override fun contentLength() = totalBytes
+            override fun source() = src
+        }
+
+        var reported = -1L
+        val body = CountingResponseBody(delegate) { reported = it }
+
+        body.source().use { src ->
+            val sink = Buffer()
+            while (src.read(sink, chunkSize.toLong()) != -1L) {
+                sink.clear() // discard immediately — never accumulate in heap
             }
         }
+
+        assertEquals("512 MB stream must be counted exactly", totalBytes, reported)
     }
 
-    @Test
-    fun fixedInterceptor_succeedsWithArabicLocale() {
-        synchronized(LOCALE_LOCK) {
-            val originalLocale = Locale.getDefault()
-            try {
-                Locale.setDefault(Locale("ar"))
-
-                MockWebServer().use { server ->
-                    server.enqueue(MockResponse()
-                        .setBody("hello")
-                        .setHeader("Content-Length", "5"))
-                    server.start()
-
-                    val client = OkHttpClient.Builder()
-                        .addInterceptor(FixedInterceptor())
-                        .build()
-
-                    val request = Request.Builder()
-                        .url(server.url("/test"))
-                        .build()
-
-                    client.newCall(request).execute().use { response ->
-                        // Should succeed without throwing
-                        val speedHeader = response.header("X-Speed-Mbps")
-                        Assert.assertNotNull("X-Speed-Mbps header should be present", speedHeader)
-
-                        // Verify the value contains only ASCII characters
-                        Assert.assertTrue(
-                            "Header value should contain only ASCII: $speedHeader",
-                            speedHeader!!.all { it.code in 0x20..0x7E }
-                        )
-                    }
-                }
-            } finally {
-                Locale.setDefault(originalLocale)
-            }
-        }
-    }
+    // --- Interceptor integration tests (MockWebServer) ----------------------
 
     @Test
-    fun fixedInterceptor_succeedsWithUSLocale() {
+    fun interceptor_usesContentLengthWhenPresent() {
         MockWebServer().use { server ->
-            server.enqueue(MockResponse()
-                .setBody("hello")
-                .setHeader("Content-Length", "5"))
+            server.enqueue(
+                MockResponse()
+                    .setBody("hello")
+                    .setHeader("Content-Length", "5")
+            )
             server.start()
 
+            val sizeOut = AtomicLong(-1)
             val client = OkHttpClient.Builder()
-                .addInterceptor(FixedInterceptor())
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut))
                 .build()
 
-            val request = Request.Builder()
-                .url(server.url("/test"))
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { it.body?.string() }
+
+            assertEquals("Should use Content-Length directly", 5L, sizeOut.get())
+        }
+    }
+
+    @Test
+    fun interceptor_countsChunkedBodyCorrectly() {
+        val body = "chunked response body"
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setChunkedBody(body, 4))
+            server.start()
+
+            val sizeOut = AtomicLong(-1)
+            val client = OkHttpClient.Builder()
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut))
                 .build()
 
-            client.newCall(request).execute().use { response ->
-                val speedHeader = response.header("X-Speed-Mbps")
-                Assert.assertNotNull(speedHeader)
-                Assert.assertTrue(speedHeader!!.all { it.code in 0x20..0x7E })
-            }
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { it.body?.string() }
+
+            assertEquals(
+                "Should count chunked body bytes correctly",
+                body.toByteArray().size.toLong(),
+                sizeOut.get()
+            )
+        }
+    }
+
+    /**
+     * 8 MB chunked response via MockWebServer — the largest safe size since
+     * MockWebServer buffers the full body before serving. Verifies that the
+     * interceptor streams without OOM and reports the exact byte count.
+     */
+    @Test
+    fun interceptor_8mb_chunkedBody_noOom() {
+        val payloadSize = 8 * 1024 * 1024
+        val payload = ByteArray(payloadSize) { (it % 256).toByte() }
+
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setChunkedBody(okio.Buffer().write(payload), 32768))
+            server.start()
+
+            val sizeOut = AtomicLong(-1)
+            val client = OkHttpClient.Builder()
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut))
+                .build()
+
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { response ->
+                    response.body?.source()?.use { src ->
+                        val sink = Buffer()
+                        while (src.read(sink, 32768) != -1L) sink.clear()
+                    }
+                }
+
+            assertEquals(payloadSize.toLong(), sizeOut.get())
+        }
+    }
+
+    @Test
+    fun interceptor_reportsZeroForEmptyBody() {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setBody(""))
+            server.start()
+
+            val sizeOut = AtomicLong(-1)
+            val client = OkHttpClient.Builder()
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut))
+                .build()
+
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { it.body?.string() }
+
+            assertTrue("Size should be >= 0 for empty body", sizeOut.get() >= 0)
+        }
+    }
+
+    @Test
+    fun interceptor_reportsCorrectly_whenBodyClosedEarly() {
+        val body = "abcdefghijklmnopqrstuvwxyz"
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse().setChunkedBody(body, 4))
+            server.start()
+
+            val sizeOut = AtomicLong(-1)
+            val client = OkHttpClient.Builder()
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut))
+                .build()
+
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { response ->
+                    response.body?.source()?.use { src ->
+                        val sink = Buffer()
+                        src.read(sink, 10) // read only first 10 bytes then close
+                    }
+                }
+
+            // onComplete must have fired via close() even without reading to EOF
+            assertTrue("onComplete should fire on early close", sizeOut.get() >= 0)
+            assertTrue("Partial read should be <= total body size", sizeOut.get() <= body.length.toLong())
         }
     }
 }

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 // ---------------------------------------------------------------------------
 // Inline copy of CountingResponseBody (no Android deps in test-runner)
@@ -69,22 +70,18 @@ class CountingResponseBody(
 
 class TestCompressedResponseSizeInterceptor(
     private val compressedSizeOut: AtomicLong,
+    private val endNanosOut: AtomicReference<Long> = AtomicReference(-1L),
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val response = chain.proceed(chain.request())
 
-        val contentLength = response.header("Content-Length")?.toLongOrNull()
+        val body = response.body ?: return response
+        val expectedSize = response.header("Content-Length")?.toLongOrNull()
             ?: response.header("content-length")?.toLongOrNull()
 
-        if (contentLength != null) {
-            compressedSizeOut.set(contentLength)
-            return response
-        }
-
-        val body = response.body ?: return response
-
         val countingBody = CountingResponseBody(body) { bytesRead ->
-            compressedSizeOut.set(bytesRead)
+            compressedSizeOut.set(expectedSize ?: bytesRead)
+            endNanosOut.set(System.nanoTime())
         }
         return response.newBuilder().body(countingBody).build()
     }
@@ -212,7 +209,48 @@ class CompressedResponseSizeInterceptorTest {
             client.newCall(Request.Builder().url(server.url("/")).build())
                 .execute().use { it.body?.string() }
 
-            assertEquals("Should use Content-Length directly", 5L, sizeOut.get())
+            assertEquals("Should report Content-Length value", 5L, sizeOut.get())
+        }
+    }
+
+    @Test
+    fun interceptor_endTimeSetAfterBodyConsumption_notHeaderReceipt() {
+        // Inserts a 100 ms delay into the body source to simulate a slow transfer.
+        // endNanos must be captured after that delay, not at header receipt time.
+        val payload = "slow body".toByteArray()
+        val delayMs = 100L
+
+        MockWebServer().use { server ->
+            server.enqueue(
+                MockResponse()
+                    .setBody("slow body")
+                    .setHeader("Content-Length", payload.size.toString())
+                    .setBodyDelay(delayMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+            )
+            server.start()
+
+            val sizeOut = AtomicLong(-1)
+            val endNanosOut = AtomicReference(-1L)
+            val interceptorStartNanos = AtomicLong(0)
+
+            val timingInterceptor = Interceptor { chain ->
+                interceptorStartNanos.set(System.nanoTime())
+                chain.proceed(chain.request())
+            }
+
+            val client = OkHttpClient.Builder()
+                .addNetworkInterceptor(timingInterceptor)
+                .addNetworkInterceptor(TestCompressedResponseSizeInterceptor(sizeOut, endNanosOut))
+                .build()
+
+            client.newCall(Request.Builder().url(server.url("/")).build())
+                .execute().use { it.body?.string() }
+
+            val elapsed = endNanosOut.get() - interceptorStartNanos.get()
+            assertTrue(
+                "endNanos must be captured after body is consumed (>= ${delayMs}ms delay), got ${elapsed / 1_000_000}ms",
+                elapsed >= delayMs * 1_000_000
+            )
         }
     }
 

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/CompressedResponseSizeInterceptorTest.kt
@@ -155,9 +155,9 @@ class CompressedResponseSizeInterceptorTest {
      * and that the byte count is exact.
      */
     @Test
-    fun countingBody_512mb_noOom() {
+    fun countingBody_64mb_noOom() {
         val chunkSize = 64 * 1024
-        val totalBytes = 512L * 1024 * 1024 // 512 MB
+        val totalBytes = 64L * 1024 * 1024 // 64 MB — large enough to catch buffering regressions
         val chunk = ByteArray(chunkSize) { 0xAB.toByte() }
 
         val delegate = object : ResponseBody() {
@@ -187,7 +187,7 @@ class CompressedResponseSizeInterceptorTest {
             }
         }
 
-        assertEquals("512 MB stream must be counted exactly", totalBytes, reported)
+        assertEquals("64 MB stream must be counted exactly", totalBytes, reported)
     }
 
     // --- Interceptor integration tests (MockWebServer) ----------------------

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
@@ -1,0 +1,304 @@
+package com.mattermost.networkclient
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * Pure-JVM tests for the internal helper functions extracted from Extensions.kt.
+ * These call the real production functions — no substitutions.
+ *
+ * Functions under test:
+ *   isMimeTypeJson, isJsonNumberFloat, stripBom, sniffIsJson, readCappedString
+ */
+
+// ---------------------------------------------------------------------------
+// Inline copies of the internal production functions.
+// These must stay byte-for-byte identical to the originals in Extensions.kt.
+// The test-runner is a plain JVM module with no Android SDK — the functions
+// themselves have no Android deps so they compile and run here as-is.
+// ---------------------------------------------------------------------------
+
+private val SNIFF_BYTES = 1024
+private val MAX_STRING_BODY_CHARS = 512 * 1024
+
+internal fun isMimeTypeJson(mimeType: String): Boolean =
+    mimeType == "application/json" ||
+        (mimeType.startsWith("application/") && mimeType.endsWith("+json")) ||
+        mimeType == "text/json"
+
+internal fun isJsonNumberFloat(raw: String): Boolean =
+    raw.contains('.') || raw.contains('e') || raw.contains('E')
+
+internal fun stripBom(stream: InputStream): java.io.PushbackInputStream {
+    val pushback = java.io.PushbackInputStream(stream, 3)
+    val bom = ByteArray(3)
+    val bomRead = pushback.read(bom, 0, 3)
+    if (bomRead > 0) {
+        val hasBom = bomRead == 3 &&
+            bom[0] == 0xEF.toByte() &&
+            bom[1] == 0xBB.toByte() &&
+            bom[2] == 0xBF.toByte()
+        if (!hasBom) pushback.unread(bom, 0, bomRead)
+    }
+    return pushback
+}
+
+internal fun sniffIsJson(stream: InputStream): Pair<Boolean, java.io.PushbackInputStream> {
+    val pushback = java.io.PushbackInputStream(stream, SNIFF_BYTES)
+    val sniffBuf = ByteArray(SNIFF_BYTES)
+    val sniffRead = pushback.read(sniffBuf, 0, SNIFF_BYTES)
+
+    var scanStart = 0
+    if (sniffRead >= 3 &&
+        sniffBuf[0] == 0xEF.toByte() &&
+        sniffBuf[1] == 0xBB.toByte() &&
+        sniffBuf[2] == 0xBF.toByte()) {
+        scanStart = 3
+    }
+
+    var firstMeaningful: Byte = 0
+    for (i in scanStart until sniffRead) {
+        val b = sniffBuf[i]
+        if (b != ' '.code.toByte() &&
+            b != '\t'.code.toByte() &&
+            b != '\n'.code.toByte() &&
+            b != '\r'.code.toByte()) {
+            firstMeaningful = b
+            break
+        }
+    }
+
+    if (sniffRead > scanStart) {
+        pushback.unread(sniffBuf, scanStart, sniffRead - scanStart)
+    }
+
+    val isJson = firstMeaningful == '{'.code.toByte() || firstMeaningful == '['.code.toByte()
+    return Pair(isJson, pushback)
+}
+
+internal fun readCappedString(stream: InputStream): String {
+    val sb = StringBuilder()
+    val charBuffer = CharArray(64 * 1024)
+    val drainBuffer = ByteArray(64 * 1024)
+    var totalChars = 0
+    java.io.InputStreamReader(stream, StandardCharsets.UTF_8).use { reader ->
+        var read = reader.read(charBuffer)
+        while (read != -1) {
+            val toAppend = minOf(read, MAX_STRING_BODY_CHARS - totalChars)
+            if (toAppend > 0) sb.append(charBuffer, 0, toAppend)
+            totalChars += read
+            if (totalChars >= MAX_STRING_BODY_CHARS) {
+                while (stream.read(drainBuffer) != -1) { /* drain */ }
+                break
+            }
+            read = reader.read(charBuffer)
+        }
+    }
+    return sb.toString()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+class ExtensionsTest {
+
+    private fun bytes(s: String) = s.toByteArray(StandardCharsets.UTF_8)
+    private val UTF8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
+    // --- isMimeTypeJson ------------------------------------------------------
+
+    @Test fun mimeType_applicationJson_isJson() = assertTrue(isMimeTypeJson("application/json"))
+    @Test fun mimeType_textJson_isJson() = assertTrue(isMimeTypeJson("text/json"))
+    @Test fun mimeType_problemJson_isJson() = assertTrue(isMimeTypeJson("application/problem+json"))
+    @Test fun mimeType_vndApiJson_isJson() = assertTrue(isMimeTypeJson("application/vnd.api+json"))
+    @Test fun mimeType_textPlain_notJson() = assertFalse(isMimeTypeJson("text/plain"))
+    @Test fun mimeType_textHtml_notJson() = assertFalse(isMimeTypeJson("text/html"))
+    @Test fun mimeType_octetStream_notJson() = assertFalse(isMimeTypeJson("application/octet-stream"))
+    @Test fun mimeType_applicationXml_notJson() = assertFalse(isMimeTypeJson("application/xml"))
+    @Test fun mimeType_empty_notJson() = assertFalse(isMimeTypeJson(""))
+
+    // --- isJsonNumberFloat ---------------------------------------------------
+
+    @Test fun number_integer_notFloat() = assertFalse(isJsonNumberFloat("42"))
+    @Test fun number_negative_notFloat() = assertFalse(isJsonNumberFloat("-7"))
+    @Test fun number_zero_notFloat() = assertFalse(isJsonNumberFloat("0"))
+    @Test fun number_decimal_isFloat() = assertTrue(isJsonNumberFloat("3.14"))
+    @Test fun number_exponentLower_isFloat() = assertTrue(isJsonNumberFloat("1e3"))
+    @Test fun number_exponentUpper_isFloat() = assertTrue(isJsonNumberFloat("1E3"))
+    @Test fun number_negativeExponent_isFloat() = assertTrue(isJsonNumberFloat("1E-3"))
+    @Test fun number_decimalWithExponent_isFloat() = assertTrue(isJsonNumberFloat("1.5e10"))
+    @Test fun number_negativeDecimal_isFloat() = assertTrue(isJsonNumberFloat("-2.0"))
+    @Test fun number_largeInteger_notFloat() = assertFalse(isJsonNumberFloat("9007199254740992"))
+
+    @Test
+    fun number_intFitsInInt_routesToInt() {
+        val raw = "42"
+        assertFalse(isJsonNumberFloat(raw))
+        val l = raw.toLong()
+        assertTrue(l in Int.MIN_VALUE..Int.MAX_VALUE)
+    }
+
+    @Test
+    fun number_longOverflowsInt_routesToDouble() {
+        val raw = "9999999999"
+        assertFalse(isJsonNumberFloat(raw))
+        val l = raw.toLong()
+        assertFalse(l in Int.MIN_VALUE..Int.MAX_VALUE)
+    }
+
+    @Test
+    fun number_exponentValues_parseCorrectly() {
+        assertEquals(1000.0, "1e3".toDouble(), 0.0)
+        assertEquals(0.001, "1E-3".toDouble(), 1e-10)
+        assertEquals(-2e10, "-2e10".toDouble(), 0.0)
+    }
+
+    // --- stripBom ------------------------------------------------------------
+
+    @Test
+    fun stripBom_withBom_bomIsConsumed() {
+        val payload = bytes("{\"k\":1}")
+        val stream = stripBom(ByteArrayInputStream(UTF8_BOM + payload))
+        val result = stream.readBytes()
+        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun stripBom_withoutBom_streamUnchanged() {
+        val payload = bytes("{\"k\":1}")
+        val stream = stripBom(ByteArrayInputStream(payload))
+        val result = stream.readBytes()
+        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun stripBom_partialBomBytes_notStripped() {
+        // Only 2 of 3 BOM bytes — must NOT be treated as a BOM
+        val partial = byteArrayOf(0xEF.toByte(), 0xBB.toByte()) + bytes("{}")
+        val stream = stripBom(ByteArrayInputStream(partial))
+        val result = stream.readBytes()
+        assertEquals(String(partial), String(result, StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun stripBom_emptyBody_noError() {
+        val stream = stripBom(ByteArrayInputStream(ByteArray(0)))
+        assertEquals(0, stream.readBytes().size)
+    }
+
+    @Test
+    fun stripBom_bomOnly_returnsEmpty() {
+        val stream = stripBom(ByteArrayInputStream(UTF8_BOM))
+        assertEquals(0, stream.readBytes().size)
+    }
+
+    // --- sniffIsJson ---------------------------------------------------------
+
+    @Test fun sniff_objectStart_isJson() = assertTrue(sniffIsJson(ByteArrayInputStream(bytes("{}"))).first)
+    @Test fun sniff_arrayStart_isJson() = assertTrue(sniffIsJson(ByteArrayInputStream(bytes("[]"))).first)
+    @Test fun sniff_plainText_notJson() = assertFalse(sniffIsJson(ByteArrayInputStream(bytes("hello"))).first)
+    @Test fun sniff_xmlStart_notJson() = assertFalse(sniffIsJson(ByteArrayInputStream(bytes("<xml/>"))).first)
+    @Test fun sniff_emptyBody_notJson() = assertFalse(sniffIsJson(ByteArrayInputStream(ByteArray(0))).first)
+    @Test fun sniff_allWhitespace_notJson() = assertFalse(sniffIsJson(ByteArrayInputStream(bytes("   \t\n\r"))).first)
+
+    @Test
+    fun sniff_leadingWhitespace_detectedAsJson() {
+        val (isJson, stream) = sniffIsJson(ByteArrayInputStream(bytes("   \t\n\r{\"k\":1}")))
+        assertTrue("Whitespace before '{' must still detect as JSON", isJson)
+        assertTrue(String(stream.readBytes(), StandardCharsets.UTF_8).trimStart().startsWith("{"))
+    }
+
+    @Test
+    fun sniff_bom_isStrippedAndJsonDetected() {
+        val (isJson, stream) = sniffIsJson(ByteArrayInputStream(UTF8_BOM + bytes("{\"k\":1}")))
+        assertTrue("BOM + '{' must detect as JSON", isJson)
+        val remaining = String(stream.readBytes(), StandardCharsets.UTF_8)
+        assertFalse("BOM must not appear in remaining stream", remaining.startsWith("﻿"))
+        assertTrue(remaining.startsWith("{"))
+    }
+
+    @Test
+    fun sniff_bomWithArray_isStrippedAndDetected() {
+        val (isJson, _) = sniffIsJson(ByteArrayInputStream(UTF8_BOM + bytes("[1,2,3]")))
+        assertTrue(isJson)
+    }
+
+    @Test
+    fun sniff_bodyLargerThanWindow_firstByteDetected() {
+        val large = bytes("{" + "x".repeat(SNIFF_BYTES * 2) + "}")
+        val (isJson, stream) = sniffIsJson(ByteArrayInputStream(large))
+        assertTrue(isJson)
+        assertEquals('{'.code.toByte(), stream.readBytes()[0])
+    }
+
+    @Test
+    fun sniff_pushbackPreservesFullStream() {
+        val body = bytes("{\"key\":\"value\"}")
+        val (_, stream) = sniffIsJson(ByteArrayInputStream(body))
+        assertEquals(String(body), String(stream.readBytes(), StandardCharsets.UTF_8))
+    }
+
+    // --- readCappedString ----------------------------------------------------
+
+    @Test
+    fun cappedString_shortBody_returnsFull() {
+        val input = "hello world"
+        assertEquals(input, readCappedString(ByteArrayInputStream(bytes(input))))
+    }
+
+    @Test
+    fun cappedString_emptyBody_returnsEmpty() {
+        assertEquals("", readCappedString(ByteArrayInputStream(ByteArray(0))))
+    }
+
+    @Test
+    fun cappedString_exactlyAtCap_returnsAll() {
+        val input = "a".repeat(MAX_STRING_BODY_CHARS)
+        val result = readCappedString(ByteArrayInputStream(bytes(input)))
+        assertEquals(MAX_STRING_BODY_CHARS, result.length)
+        assertTrue(result.all { it == 'a' })
+    }
+
+    @Test
+    fun cappedString_overCap_truncatesAtCap() {
+        val input = "b".repeat(MAX_STRING_BODY_CHARS * 2)
+        val result = readCappedString(ByteArrayInputStream(bytes(input)))
+        assertEquals(MAX_STRING_BODY_CHARS, result.length)
+        assertTrue(result.all { it == 'b' })
+    }
+
+    @Test
+    fun cappedString_overCap_drainsDontAccumulate() {
+        // Verify that excess bytes beyond the cap don't end up in the result —
+        // the drain loop must consume them silently.
+        val belowCap = "a".repeat(MAX_STRING_BODY_CHARS)
+        val excess = "Z".repeat(MAX_STRING_BODY_CHARS)
+        val result = readCappedString(ByteArrayInputStream(bytes(belowCap + excess)))
+        assertEquals(MAX_STRING_BODY_CHARS, result.length)
+        assertFalse("Drained excess must not appear in result", result.contains('Z'))
+    }
+
+    @Test
+    fun cappedString_multibyteUtf8_truncatesOnCharBoundary() {
+        // Each '€' is 3 UTF-8 bytes but 1 UTF-16 char.
+        val overCap = "€".repeat(MAX_STRING_BODY_CHARS + 1)
+        val result = readCappedString(ByteArrayInputStream(bytes(overCap)))
+        assertEquals(MAX_STRING_BODY_CHARS, result.length)
+    }
+
+    @Test
+    fun cappedString_closesStream() {
+        var closed = false
+        val stream = object : ByteArrayInputStream(bytes("data")) {
+            override fun close() { closed = true; super.close() }
+        }
+        readCappedString(stream)
+        assertTrue("Stream must be closed after readCappedString", closed)
+    }
+}

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
@@ -86,7 +86,6 @@ internal fun sniffIsJson(stream: InputStream): Pair<Boolean, java.io.PushbackInp
 internal fun readCappedString(stream: InputStream): String {
     val sb = StringBuilder()
     val charBuffer = CharArray(64 * 1024)
-    val drainBuffer = ByteArray(64 * 1024)
     var totalChars = 0
     java.io.InputStreamReader(stream, StandardCharsets.UTF_8).use { reader ->
         var read = reader.read(charBuffer)
@@ -95,6 +94,7 @@ internal fun readCappedString(stream: InputStream): String {
             if (toAppend > 0) sb.append(charBuffer, 0, toAppend)
             totalChars += read
             if (totalChars >= MAX_STRING_BODY_CHARS) {
+                val drainBuffer = ByteArray(64 * 1024)
                 while (stream.read(drainBuffer) != -1) { /* drain */ }
                 break
             }

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
@@ -168,7 +168,7 @@ class ExtensionsTest {
         val payload = bytes("{\"k\":1}")
         val stream = stripBom(ByteArrayInputStream(UTF8_BOM + payload))
         val result = stream.readBytes()
-        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
+        assertEquals(String(payload, StandardCharsets.UTF_8), String(result, StandardCharsets.UTF_8))
     }
 
     @Test
@@ -176,7 +176,7 @@ class ExtensionsTest {
         val payload = bytes("{\"k\":1}")
         val stream = stripBom(ByteArrayInputStream(payload))
         val result = stream.readBytes()
-        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
+        assertEquals(String(payload, StandardCharsets.UTF_8), String(result, StandardCharsets.UTF_8))
     }
 
     @Test
@@ -185,7 +185,7 @@ class ExtensionsTest {
         val partial = byteArrayOf(0xEF.toByte(), 0xBB.toByte()) + bytes("{}")
         val stream = stripBom(ByteArrayInputStream(partial))
         val result = stream.readBytes()
-        assertEquals(String(partial), String(result, StandardCharsets.UTF_8))
+        assertEquals(String(partial, StandardCharsets.UTF_8), String(result, StandardCharsets.UTF_8))
     }
 
     @Test
@@ -243,7 +243,7 @@ class ExtensionsTest {
     fun sniff_pushbackPreservesFullStream() {
         val body = bytes("{\"key\":\"value\"}")
         val (_, stream) = sniffIsJson(ByteArrayInputStream(body))
-        assertEquals(String(body), String(stream.readBytes(), StandardCharsets.UTF_8))
+        assertEquals(String(body, StandardCharsets.UTF_8), String(stream.readBytes(), StandardCharsets.UTF_8))
     }
 
     @Test
@@ -265,7 +265,7 @@ class ExtensionsTest {
         val (isJson, stream) = sniffIsJson(slowStream)
         assertTrue("Short-read stream with '{' must still detect as JSON", isJson)
         val remaining = String(stream.readBytes(), StandardCharsets.UTF_8)
-        assertEquals(String(body), remaining)
+        assertEquals(String(body, StandardCharsets.UTF_8), remaining)
     }
 
     @Test
@@ -284,7 +284,7 @@ class ExtensionsTest {
         }
         val stream = stripBom(slowStream)
         val result = stream.readBytes()
-        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
+        assertEquals(String(payload, StandardCharsets.UTF_8), String(result, StandardCharsets.UTF_8))
     }
 
     // --- readCappedString ----------------------------------------------------

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
@@ -37,7 +37,12 @@ internal fun isJsonNumberFloat(raw: String): Boolean =
 internal fun stripBom(stream: InputStream): java.io.PushbackInputStream {
     val pushback = java.io.PushbackInputStream(stream, 3)
     val bom = ByteArray(3)
-    val bomRead = pushback.read(bom, 0, 3)
+    var bomRead = 0
+    while (bomRead < 3) {
+        val n = pushback.read(bom, bomRead, 3 - bomRead)
+        if (n == -1) break
+        bomRead += n
+    }
     if (bomRead > 0) {
         val hasBom = bomRead == 3 &&
             bom[0] == 0xEF.toByte() &&
@@ -49,20 +54,17 @@ internal fun stripBom(stream: InputStream): java.io.PushbackInputStream {
 }
 
 internal fun sniffIsJson(stream: InputStream): Pair<Boolean, java.io.PushbackInputStream> {
-    val pushback = java.io.PushbackInputStream(stream, SNIFF_BYTES)
+    val pushback = java.io.PushbackInputStream(stripBom(stream), SNIFF_BYTES)
     val sniffBuf = ByteArray(SNIFF_BYTES)
-    val sniffRead = pushback.read(sniffBuf, 0, SNIFF_BYTES)
-
-    var scanStart = 0
-    if (sniffRead >= 3 &&
-        sniffBuf[0] == 0xEF.toByte() &&
-        sniffBuf[1] == 0xBB.toByte() &&
-        sniffBuf[2] == 0xBF.toByte()) {
-        scanStart = 3
+    var sniffRead = 0
+    while (sniffRead < SNIFF_BYTES) {
+        val n = pushback.read(sniffBuf, sniffRead, SNIFF_BYTES - sniffRead)
+        if (n == -1) break
+        sniffRead += n
     }
 
     var firstMeaningful: Byte = 0
-    for (i in scanStart until sniffRead) {
+    for (i in 0 until sniffRead) {
         val b = sniffBuf[i]
         if (b != ' '.code.toByte() &&
             b != '\t'.code.toByte() &&
@@ -73,8 +75,8 @@ internal fun sniffIsJson(stream: InputStream): Pair<Boolean, java.io.PushbackInp
         }
     }
 
-    if (sniffRead > scanStart) {
-        pushback.unread(sniffBuf, scanStart, sniffRead - scanStart)
+    if (sniffRead > 0) {
+        pushback.unread(sniffBuf, 0, sniffRead)
     }
 
     val isJson = firstMeaningful == '{'.code.toByte() || firstMeaningful == '['.code.toByte()
@@ -242,6 +244,47 @@ class ExtensionsTest {
         val body = bytes("{\"key\":\"value\"}")
         val (_, stream) = sniffIsJson(ByteArrayInputStream(body))
         assertEquals(String(body), String(stream.readBytes(), StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun sniff_shortReadStream_stillDetectsJson() {
+        // Simulates an InputStream that delivers bytes in 1-byte chunks — the
+        // classic short-read scenario. Without the fill loop, a single read()
+        // call returns only 1 byte and the '{' at position 0 is never seen.
+        val body = bytes("{\"key\":\"value\"}")
+        val slowStream = object : InputStream() {
+            private var pos = 0
+            override fun read(): Int = if (pos < body.size) body[pos++].toInt() and 0xFF else -1
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                // Deliver at most 1 byte per call
+                if (pos >= body.size) return -1
+                b[off] = body[pos++]
+                return 1
+            }
+        }
+        val (isJson, stream) = sniffIsJson(slowStream)
+        assertTrue("Short-read stream with '{' must still detect as JSON", isJson)
+        val remaining = String(stream.readBytes(), StandardCharsets.UTF_8)
+        assertEquals(String(body), remaining)
+    }
+
+    @Test
+    fun stripBom_shortReadStream_stillStrippedCorrectly() {
+        // Simulates a stream that delivers the BOM 1 byte at a time.
+        val payload = bytes("{}")
+        val input = UTF8_BOM + payload
+        val slowStream = object : InputStream() {
+            private var pos = 0
+            override fun read(): Int = if (pos < input.size) input[pos++].toInt() and 0xFF else -1
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                if (pos >= input.size) return -1
+                b[off] = input[pos++]
+                return 1
+            }
+        }
+        val stream = stripBom(slowStream)
+        val result = stream.readBytes()
+        assertEquals(String(payload), String(result, StandardCharsets.UTF_8))
     }
 
     // --- readCappedString ----------------------------------------------------

--- a/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
+++ b/test-runner/src/test/kotlin/com/mattermost/networkclient/ExtensionsTest.kt
@@ -9,18 +9,18 @@ import java.io.InputStream
 import java.nio.charset.StandardCharsets
 
 /**
- * Pure-JVM tests for the internal helper functions extracted from Extensions.kt.
- * These call the real production functions — no substitutions.
+ * Pure-JVM tests for the internal helper functions from Extensions.kt.
+ *
+ * The test-runner has no Android SDK, so the helpers are duplicated below
+ * rather than imported. These copies MUST be kept in sync with Extensions.kt
+ * whenever the originals change.
  *
  * Functions under test:
  *   isMimeTypeJson, isJsonNumberFloat, stripBom, sniffIsJson, readCappedString
  */
 
 // ---------------------------------------------------------------------------
-// Inline copies of the internal production functions.
-// These must stay byte-for-byte identical to the originals in Extensions.kt.
-// The test-runner is a plain JVM module with no Android SDK — the functions
-// themselves have no Android deps so they compile and run here as-is.
+// Inline copies of the internal production functions (no Android deps).
 // ---------------------------------------------------------------------------
 
 private val SNIFF_BYTES = 1024


### PR DESCRIPTION
#### Summary
Replace full-body buffering in CompressedResponseSizeInterceptor and toWritableMap with streaming alternatives: CountingResponseBody counts bytes lazily as the body is consumed, and toWritableMap uses android.util.JsonReader to parse JSON token-by-token without an intermediate String. Non-JSON bodies are capped at 512K chars with the remainder drained. Content-Type and 1 KB sniffing with UTF-8 BOM stripping determine the parse path. Adds tests for all new pure-JVM helpers.

Fixes reported crashed for:
com.mattermost.networkclient.interceptors.CompressedResponseSizeInterceptor.intercept
java.lang.OutOfMemoryError

okio.Segment.<init>
java.lang.OutOfMemoryError

