### PR TITLE
fix: standalone podspec for session attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ npm install @mattermost/react-native-network-client
 
 You will also need to update your applications Podfile to use our fork of Starscream. See the [example app's Podfile](https://github.com/mattermost/react-native-network-client/blob/master/example/ios/Podfile#L31).
 
+### iOS: session attributes pod
+
+On iOS this library depends on a companion pod, `react-native-network-client-session-attributes`, which ships in this same npm package. It is not published to the CocoaPods CDN, so autolinking cannot resolve it on its own — add it to your Podfile with an explicit path:
+
+```ruby
+pod 'react-native-network-client-session-attributes', :path => '../node_modules/@mattermost/react-native-network-client'
+```
+
+One such line anywhere in the Podfile is enough: CocoaPods resolves external sources per Podfile rather than per target, so any target that requires the pod (including the main app, which gets it transitively via `react-native-network-client`) will then find it. Without it, `pod install` fails with `Unable to find a specification for react-native-network-client-session-attributes`.
+
+
 ## Usage
 
 ```js

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
-gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
+gem 'cocoapods', '1.16.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
-gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,29 +1,26 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.16.1)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.16.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -37,8 +34,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+      xcodeproj (>= 1.26.0, < 2.0)
+    cocoapods-core (1.16.1)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -60,38 +57,42 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.2.2)
     escape (0.0.4)
-    ethon (0.16.0)
+    ethon (0.18.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+      logger
+    ffi (1.17.4-arm64-darwin)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    httpclient (2.8.3)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
+    json (2.21.2)
     logger (1.7.0)
     minitest (5.20.0)
     molinillo (0.8.0)
     mutex_m (0.3.0)
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
+    nkf (0.3.0)
     public_suffix (4.0.7)
-    rexml (3.2.6)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.28.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
+      base64
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      nanaimo (~> 0.4.0)
+      nkf
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   arm64-darwin-22
@@ -102,14 +103,9 @@ DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
   benchmark
   bigdecimal
-  cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
+  cocoapods (= 1.16.1)
   logger
   mutex_m
-  xcodeproj (< 1.26.0)
-
-RUBY VERSION
-   ruby 3.2.0p0
 
 BUNDLED WITH
    2.3.26

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -34,6 +34,11 @@ target 'NetworkClientExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
+  # react-native-network-client depends on this sibling pod, which is not published
+  # to the CocoaPods CDN, so autolinking cannot resolve it on its own. Declaring it
+  # with an explicit path lets CocoaPods find it locally.
+  pod 'react-native-network-client-session-attributes', :path => '../../'
+
   post_install do |installer|
     react_native_post_install(
       installer,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1455,7 +1455,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-network-client (1.9.3):
+  - react-native-network-client (1.11.0):
     - Alamofire (~> 5.11.2)
     - hermes-engine
     - RCTRequired
@@ -1468,6 +1468,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
+    - react-native-network-client-session-attributes
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1480,6 +1481,7 @@ PODS:
     - Starscream (~> 4.0.8)
     - SwiftyJSON (~> 5.0.2)
     - Yoga
+  - react-native-network-client-session-attributes (1.11.0)
   - react-native-safe-area-context (5.7.0):
     - hermes-engine
     - RCTRequired
@@ -2258,6 +2260,7 @@ DEPENDENCIES:
   - "react-native-document-picker (from `../node_modules/@react-native-documents/picker`)"
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - "react-native-network-client (from `../node_modules/@mattermost/react-native-network-client`)"
+  - react-native-network-client-session-attributes (from `../../`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
@@ -2400,6 +2403,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-image-picker"
   react-native-network-client:
     :path: "../node_modules/@mattermost/react-native-network-client"
+  react-native-network-client-session-attributes:
+    :path: "../../"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
@@ -2504,94 +2509,95 @@ SPEC CHECKSUMS:
   RCTDeprecation: 9502b5eb8e3c9eb75ff5a333b2c591bab9d91e28
   RCTRequired: 0268a5d86aef1defea2e04289d74fdf3570197c1
   RCTSwiftUI: cff211c5e4d94e491dda240d663b8effd25296d7
-  RCTSwiftUIWrapper: 1f3611e0714470be04cdb9d0875d23fead6b1dd8
+  RCTSwiftUIWrapper: b731e4d3257895dfcc4bbe2dc3ae24249cd55f6e
   RCTTypeSafety: c6ed564d0d54c9a01be7db724fbc753eb77b3dc1
   React: 9b033c7a99e1c8eec40960b6b2e6844e011e8bd1
   React-callinvoker: f64c8d57f45173835b6b9891cda27f1625551972
-  React-Core: 7e1136eecefd040dc95b06301778dbfd8a61c32a
+  React-Core: 341863a2597c4a2320f916b4232d280cb8a28e4b
   React-Core-prebuilt: a3e7f8851ee793bc8837400e5ffb6d62eaeb55b5
-  React-CoreModules: 5ce99b935ea174a7fedb6c1066dd6b66feae2c04
-  React-cxxreact: d45093410e3cd016ea47d4a73a2295a46d6c72bb
+  React-CoreModules: 9370769c9b2b1732c58960687f4d50d9d3510efc
+  React-cxxreact: 41ae74bd9eab80af9c5da6a9b4934eb97e2c7569
   React-debug: 5c23edcf01e5a23af51055912de7e435539b8c63
-  React-defaultsnativemodule: 5a7dda0fbb02883b69511982e2ce71ac6f1601be
-  React-domnativemodule: faeacd149a1bfa879c818f51bc7dedbe23cf2e5b
-  React-Fabric: b4d281b754c388977b034980c766bed3716716ab
-  React-FabricComponents: 3e8acb14368ac214129824349299cc005f6bfcfd
-  React-FabricImage: 6a8f8cef14536d12688ce868845f7d010075fdd6
-  React-featureflags: b9d6cfb38a589236b1ea62005f6cb8d529f8d338
-  React-featureflagsnativemodule: ac0d3c6c84d403dea70c79b42f34198e0c7a0fe4
-  React-graphics: 265c82654dcecd77ff7f6c93fe52b35688448298
-  React-hermes: 34cba83cf2b11638565b4a513238d5e277ce9c35
-  React-idlecallbacksnativemodule: e77b7fb74c8375cb31aba5f641a3ec3c62b99ec0
-  React-ImageManager: db216f3a3d3a6fe54623d6184d930f785cb50ae7
-  React-intersectionobservernativemodule: dec4ee524a6ab4b04c850ffb36c00c06e7d83962
-  React-jserrorhandler: 76911619d9a0424d8a08463ce4fac8e91d1fe648
-  React-jsi: ab2c8ac31f9d7a9345389077fcd5d2a6732d3668
-  React-jsiexecutor: 1938f86c177d43ae1664ca41a60bce0e69a5fe67
-  React-jsinspector: 6f1bf8ea7b074e912491cfa428d5c03f2fb3bb13
-  React-jsinspectorcdp: aa4146665aaede17580d5304abfd891a3b521803
-  React-jsinspectornetwork: 52498c3e2b40c96cac710e887321a33b0d30582c
-  React-jsinspectortracing: 938ef1f67e2f3eee28b8abda2a5c5ef7c049ef9b
-  React-jsitooling: f748001b0d63162e0d858cf829f68903287685f8
-  React-jsitracing: e06fe93e09d3ccb24741a69e9a03d9093c1e7288
-  React-logger: 8f320ad2007af122573c11ced727bf3ef795c58b
-  React-Mapbuffer: 708dd93eb92271f0b90ad44ef7bd39627ee28de7
-  React-microtasksnativemodule: 596952fb1cb3e54d575b57f9fe159d663241aaca
-  react-native-document-picker: 3a0bff3cf9349e67ae3e88fc163444bb58d23f0f
-  react-native-image-picker: 20ad0f669770f020675cf8c7013a51c8a5490889
-  react-native-network-client: d8c34a59582f2f8daae70cb90e5350da75a0e088
-  react-native-safe-area-context: 578cbb828d4f0795bcf14adfb3e7e481a5be6f62
-  React-NativeModulesApple: 9af02ea7a28301aee846322b8ba14eeed9077c2e
-  React-networking: 9eb04193ac1e572a2a63ca83beae5bb9ba966517
+  React-defaultsnativemodule: d8ad85d93788b33e319b7e748220aad6f90e8497
+  React-domnativemodule: 4e88718c7cd6e8fc269f862d5af748f0f4c54b7d
+  React-Fabric: 294c9e5cfd019636fc5e181e71b4169efd0bb36a
+  React-FabricComponents: 27002924e6458a7ef1f3613d3fb73e2dacfc0f45
+  React-FabricImage: 5ad8b76a7bd4d66123dbd446e82f30dff76c8c45
+  React-featureflags: 3bad0368c40c6b68976f26582f90b8fc4157428f
+  React-featureflagsnativemodule: 77d809fc4d4e4d7d3e0509314f51762492f933f4
+  React-graphics: ea74c7b3735db1131e3974447c5deee0c644805f
+  React-hermes: feafb2b23ca8a4c5a1892681ca12970c0861b2f5
+  React-idlecallbacksnativemodule: eac296e1e62b4c5aa389eb0e4d52fc0b1f9b7f6b
+  React-ImageManager: 55f2c499eb716e1f553bae7b3f72bb6eb050ea06
+  React-intersectionobservernativemodule: 4f364d5457918a3c3fa9c69b88baeb9aeaf76203
+  React-jserrorhandler: 469580fdec26609f5549ba0c9751b243b99d507f
+  React-jsi: 98e544352782dad976e1bb9e428e572f5e618978
+  React-jsiexecutor: cd242143c5973359a28edd6accfdfe8b281fd07d
+  React-jsinspector: 2a1e31e4af71e0179eaacfb51b3aeefa7bab4131
+  React-jsinspectorcdp: 6cd310dcdf51da443b7e4a80b08eb1308b31ad38
+  React-jsinspectornetwork: cee9e826a2f048e5a06de82735513c39a7919210
+  React-jsinspectortracing: a2ebff4a21c37bfd8bf91fe8caca2713ce26975b
+  React-jsitooling: 6e79721d7075fbf93d720702a0c3f0eca0f031e4
+  React-jsitracing: f1f043a2c0d5dfd2fbcb787fdb0dfe447f9b23d8
+  React-logger: 702a49dadb10a6bd63d56b297c3350b5ea552141
+  React-Mapbuffer: 9f7f3ec89517942f86aed77cb4712dedf2d327c8
+  React-microtasksnativemodule: d2241f88c1cb03feed6e24c256992ba39ea84717
+  react-native-document-picker: 5b20fbc3ac7aaa8402bc86958c0a859758754a33
+  react-native-image-picker: 4123dc2b15a0b6fc2f027e6cf94ae5f48c9ae9b0
+  react-native-network-client: f62ce7e10ab164285bb0a5445303367843e9a598
+  react-native-network-client-session-attributes: 304ec2ecb0036803ed2cce9e672029ba5c08b980
+  react-native-safe-area-context: 90476586077446d5eab1d41ac3e767b016ac41d6
+  React-NativeModulesApple: 9068613f7650828eed29ead6fc0d0a1620117e6a
+  React-networking: 96d4cbebde99461fcb0d631c546a905494cb7a68
   React-oscompat: 05afae2c7689405dbb4f6458110d501d55357980
-  React-perflogger: 259510beef61c32e2181d8e47145128212b0cbe9
-  React-performancecdpmetrics: 20412c24201b57ddc72845d481ee6ce43a8521ff
-  React-performancetimeline: c8a96100567d96a53b60c314b457a16517515025
+  React-perflogger: e3b6c4e302c1db7ef30ea2484d22350cb91ed209
+  React-performancecdpmetrics: 3ea2c879618c8dffa10db39f8e4d8b4a550cf7c6
+  React-performancetimeline: 9b9d57a6a43bf5ef1e3e94e0f101dabd3ed5e011
   React-RCTActionSheet: 6905f5568a98e1466071904ecce56f412477276b
-  React-RCTAnimation: 66844a336709a250b0224cc6c1daa99c24ec3496
-  React-RCTAppDelegate: e7a5cdf1a7d62d8a1eeec607c383422bf57c65c9
-  React-RCTBlob: 766364e4e0640ebcda9fb96f2c69b48ddf0b2827
-  React-RCTFabric: a7bb7985e2ac6e9647b620d42585997a80277265
-  React-RCTFBReactNativeSpec: e791df1d8e5fa2453486f155e76cd7687193fd20
-  React-RCTImage: 7562c4007aef3651153a9a79e445c8d533cb95f7
-  React-RCTLinking: 72e6b6b6108415261edbb4fae68c3c76379c9a45
-  React-RCTNetwork: d0439b9ebbdcc3a27fe8a6f64c50ce78e25219aa
-  React-RCTRuntime: ec5088d165f249ebbfe0213d1f4d513b4ff33774
-  React-RCTSettings: b3fd002ab3d547c016b6f94291f8a2d4f46dcc86
-  React-RCTText: 5ec0e83e10d8691fe53d84bf89a5c19a7618bf13
-  React-RCTVibration: fc60c99150aa20a64909d3a72a7cc1b289d93ccb
+  React-RCTAnimation: 2296d52d6ea82e69c5019b8def1e7fd6c2adbeed
+  React-RCTAppDelegate: 1fe1d13018c2f556b583819219f7de73d5b70a68
+  React-RCTBlob: fa1130cb4e2f880ddc6cd910543d1e634330ee72
+  React-RCTFabric: dd0277d26a192829a41a3c9f1d2924bcd4bec666
+  React-RCTFBReactNativeSpec: 9eae1f6dfadabd964b51599cf331e3417fd45eaa
+  React-RCTImage: cdae5d3d50e30ff8eb587134a87f742d37bc795a
+  React-RCTLinking: eeb33d8033a41c0ebab879110063a25f1a282f45
+  React-RCTNetwork: 066703b5cc088bd682f748a0d6b0fe7fbabc898f
+  React-RCTRuntime: 4b325369df7fe09f189c48d9fd3eb35d54f05f17
+  React-RCTSettings: 5fc7087bc8fd37c43f727ad7840d9014fb14625b
+  React-RCTText: 3e79e3df3a37e7ecf75b0a19815b8031531bfb06
+  React-RCTVibration: bfbc37851c3fb413ca206d768c1745fb9fce7cc4
   React-rendererconsistency: 2c5ef7920396db1c946a39e7722c07b45a29d840
-  React-renderercss: 91346750b2b3cd4693f951cea006e96a77aa50b7
-  React-rendererdebug: 586acc558a13330aef28a5fe5f454f4d6188f46c
-  React-RuntimeApple: d61362d54f5708980088a817fce6a66b8652f30c
-  React-RuntimeCore: 8f9717230ed1b4c7eca0542d9edf5cfaca669f33
-  React-runtimeexecutor: 31dd42441bfec38851d768cfc506f9c2a8145aed
-  React-RuntimeHermes: 370f5625044e65d6ad2341c94ca766923e25eea4
-  React-runtimescheduler: 32c5f3e8deb5592453b94bb0cf06431d1dc80245
-  React-timing: 6daa9dd47272fdc67b63bc10a5cad63ded2755a8
-  React-utils: 852f45b6e36c453b585208ab9392039371c60f80
-  React-webperformancenativemodule: b6028c033abac71deac5d41316ac32de30091dfe
-  ReactAppDependencyProvider: 8c8beef1d44fe57dfd1fb42a20ba57efba1dcaee
-  ReactCodegen: 136d44c61dbc89b4f6f4572bad5ef4a938d326b3
-  ReactCommon: 5887143a2b315f8cfc06648302600330a59a4fc4
+  React-renderercss: 91dbf2d25b5dd4b7dc11b33b2514cf4aba5ad496
+  React-rendererdebug: 1b531aed85297b626aa03b153d880360a1d1e118
+  React-RuntimeApple: 871a500ad8fd50b17b90dbda7d8d0254670cf33f
+  React-RuntimeCore: 799e5e2b82122962f591fbd777a96b8010e0cfd4
+  React-runtimeexecutor: 45c724f9bec89b67850971eb2fdd76ccc379730e
+  React-RuntimeHermes: cd0d342dd22c1cc87cd0780d22bb5b048346ec28
+  React-runtimescheduler: d28db47e3bd5b174835b1214d56cbbdb6d05cf54
+  React-timing: b394613b482a12608780395c8441b2501ea5e087
+  React-utils: 2d0f701488f117c1ad2edbab19aaddc5abef28af
+  React-webperformancenativemodule: ad791ed0f4ca68428f2d7c2898385a90d83f220b
+  ReactAppDependencyProvider: 3ec8fc5d32ad422f5b805523a5a5ea5556d8b3a2
+  ReactCodegen: 68b032512e57ceda2588d6a418083facf2a4c311
+  ReactCommon: ba28cd4e7d9e24014d2772a80e32da020c732b00
   ReactNativeDependencies: 9916a59842264050c10400b71f124719d4e6b2f5
-  RNCCheckbox: 471ebdc33884c084f362615c1ef3507496cc07f1
-  RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
-  RNDeviceInfo: d79872e11c8e9c4de0d65b0ee6e0cee719f37fea
-  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
-  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: f6b7d168f609b6f8fe37162d2ef32192e5ef2ce9
-  RNPermissions: bdba229f3f16de5140ef82a370cd8d567b1d4c99
-  RNReanimated: 48371922b8797e2b8205889cab49932be0dd7699
-  RNScreens: 3fdf5b703b1a4c2e270b34c8127edc575114e599
-  RNVectorIcons: 63e011d60ff13ccece9646df93ba53f753954987
-  RNWorklets: 2a028a0b01413c423e6945b8b7619c3cdd687266
+  RNCCheckbox: 33b44487ca8008394ce658cc32b26eab04f426ef
+  RNCMaskedView: 4c5ee1c8667d56077246cc6d1977f77393923560
+  RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e
+  RNFastImage: 462a183c4b0b6b26fdfd639e1ed6ba37536c3b87
+  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
+  RNGestureHandler: 463dba1dccda8fd5b91921a33968799cdc72f9d0
+  RNPermissions: 449967cdf5b232cf2eae78cf7c1e4c63038f013d
+  RNReanimated: 9ffa2fc182274feaaf6f9ba46c8118228cdec714
+  RNScreens: ca829379d20b0d1ff41a0b87bc37bdc50276cef5
+  RNVectorIcons: 1db72384402bc567e995855056b8c5d7a9888780
+  RNWorklets: 9e58fb4eb675a5e582cb38aee96698ae86e905c9
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   Starscream: 19b5533ddb925208db698f0ac508a100b884a1b9
   SwiftyJSON: f5b1bf1cd8dd53cd25887ac0eabcfd92301c6a5a
   Yoga: f6a505247d21ee720d1ea0463dbe6ac95116c644
 
-PODFILE CHECKSUM: 880922436ae40d8e32a1c1e3b1a1cdd4a6127d61
+PODFILE CHECKSUM: bd2c4c20fbec09780596b949022c326633595392
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.1

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -64,7 +64,7 @@
     },
     "..": {
       "name": "@mattermost/react-native-network-client",
-      "version": "1.9.3",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "validator": "13.15.35",

--- a/ios/Adapters/SessionAttributesAdapter.swift
+++ b/ios/Adapters/SessionAttributesAdapter.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 import Alamofire
+import react_native_network_client_session_attributes
 
 @objc public class SessionAttributesAdapter: NSObject, RequestAdapter {
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {

--- a/ios/ApiClient/ApiClientWrapper.swift
+++ b/ios/ApiClient/ApiClientWrapper.swift
@@ -1,6 +1,7 @@
 import Alamofire
 import SwiftyJSON
 import React
+import react_native_network_client_session_attributes
 
 @objc public class ApiClientWrapper: NSObject, NetworkClient {
     @objc public weak var delegate: ApiClientDelegate? = nil

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ios",
     "cpp",
     "react-native-network-client.podspec",
+    "react-native-network-client-session-attributes.podspec",
     "!lib/typescript/example",
     "!**/__tests__",
     "!**/__fixtures__",

--- a/react-native-network-client-session-attributes.podspec
+++ b/react-native-network-client-session-attributes.podspec
@@ -1,0 +1,44 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+# Standalone, React-free pod for the SessionAttributes sources.
+#
+# This is a sibling ROOT spec rather than a subspec of react-native-network-client
+# on purpose. As a subspec it shared the root spec's module name, so the two pod
+# targets CocoaPods generates (the app links it via the `Core` default subspec,
+# while the notification/share extensions link it alone) both produced
+# react_native_network_client.framework. Regular builds gave each pod target its
+# own CONFIGURATION_BUILD_DIR and never collided, but archiving redirects products
+# into a single shared directory, where the duplicate product broke the build with
+# "Multiple commands produce ... react_native_network_client.framework".
+#
+# A root spec owns its own module name, so it is built once and shared by the app
+# and both extensions. CocoaPods rejects `module_name` on a subspec, which is why
+# the collision cannot be fixed in place.
+#
+# The sources here depend only on system frameworks (Foundation, Network,
+# NetworkExtension, SystemConfiguration, CryptoKit), which is what makes them
+# safe to link into app extensions.
+#
+# Swift module name is react_native_network_client_session_attributes (CocoaPods
+# replaces the hyphens in the pod name with underscores).
+Pod::Spec.new do |s|
+  s.name         = "react-native-network-client-session-attributes"
+  s.version      = package["version"]
+  s.summary      = "React-free session attributes collection for Mattermost clients"
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+
+  s.platforms    = { :ios => "15.1" }
+  s.source       = { :git => "https://github.com/mattermost/react-native-network-client.git", :tag => "#{s.version}" }
+
+  s.source_files = "ios/SessionAttributes/**/*.swift"
+
+  s.pod_target_xcconfig = {
+    "DEFINES_MODULE" => "YES",
+    "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
+    "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface"
+  }
+end

--- a/react-native-network-client.podspec
+++ b/react-native-network-client.podspec
@@ -14,41 +14,36 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mattermost/react-native-network-client.git", :tag => "#{s.version}" }
   s.prepare_command = 'ruby ios/patches/apply_patches.rb'
 
-  # SessionAttributes lives in its own React-free subspec so it can be linked by
-  # app extensions / standalone native code without pulling in React.
-  s.subspec 'SessionAttributes' do |sa|
-    sa.source_files = 'ios/SessionAttributes/**/*.swift'
-    sa.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+
+  # SessionAttributes lives in the sibling React-free
+  # react-native-network-client-session-attributes podspec so app extensions and
+  # standalone native code can link it without pulling in React, and so it resolves
+  # to a single shared pod target (see that podspec for why it is not a subspec).
+  # Excluded here so those files are compiled exactly once, by that pod.
+  s.exclude_files = "ios/SessionAttributes/**/*"
+  s.dependency 'react-native-network-client-session-attributes'
+
+  fabric_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+
+  if fabric_enabled
+    s.pod_target_xcconfig    = {
+      "DEFINES_MODULE" => "YES",
+      "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
+      "OTHER_CPLUSPLUSFLAGS" => "-DRCT_NEW_ARCH_ENABLED=1",
+      "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface"
+    }
+  else
+    s.pod_target_xcconfig    = {
+      "DEFINES_MODULE" => "YES",
+      "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
+      "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface"
+    }
   end
 
-  s.subspec 'Core' do |core|
-    core.source_files = "ios/**/*.{h,m,mm,swift}"
-    core.exclude_files = "ios/SessionAttributes/**/*"
-    core.dependency 'react-native-network-client/SessionAttributes'
+  install_modules_dependencies(s)
 
-    fabric_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
-
-    if fabric_enabled
-      core.pod_target_xcconfig    = {
-        "DEFINES_MODULE" => "YES",
-        "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
-        "OTHER_CPLUSPLUSFLAGS" => "-DRCT_NEW_ARCH_ENABLED=1",
-        "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface"
-      }
-    else
-      core.pod_target_xcconfig    = {
-        "DEFINES_MODULE" => "YES",
-        "BUILD_LIBRARY_FOR_DISTRIBUTION" => "YES",
-        "OTHER_SWIFT_FLAGS" => "-no-verify-emitted-module-interface"
-      }
-    end
-
-    install_modules_dependencies(core)
-
-    core.dependency "Alamofire", "~> 5.11.2"
-    core.dependency "SwiftyJSON", "~> 5.0.2"
-    core.dependency "Starscream", "~> 4.0.8"
-  end
-
-  s.default_subspec = 'Core'
+  s.dependency "Alamofire", "~> 5.11.2"
+  s.dependency "SwiftyJSON", "~> 5.0.2"
+  s.dependency "Starscream", "~> 4.0.8"
 end


### PR DESCRIPTION
#### Summary
Here we split the session attributes pod spec into its own module so that we can clearly use them without causing conflicts.
