### PR TITLE
[MM-70388] Fix SSID collection under VPN and after location authorization

### DIFF
--- a/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
+++ b/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
@@ -90,9 +90,10 @@ class SessionAttributesCollector(
         val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
 
         val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+        val wifiActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
         val interfaceType = when {
             vpnActive -> "vpn"
-            capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true -> "wifi"
+            wifiActive -> "wifi"
             capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> "cellular"
             capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true -> "ethernet"
             activeNetwork == null -> ""
@@ -100,7 +101,7 @@ class SessionAttributesCollector(
         }
 
         val ipAddress = resolveIpAddress()
-        val ssid = if (interfaceType == "wifi") resolveSsid() else ""
+        val ssid = if (wifiActive) resolveSsid() else ""
 
         return NetworkSnapshot(interfaceType, ipAddress, vpnActive, ssid)
     }

--- a/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
+++ b/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
@@ -90,12 +90,9 @@ class SessionAttributesCollector(
         val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
 
         val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
-        val wifiActive = connectivityManager.allNetworks.any { network ->
-            connectivityManager.getNetworkCapabilities(network)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
-        }
         val interfaceType = when {
             vpnActive -> "vpn"
-            wifiActive -> "wifi"
+            capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true -> "wifi"
             capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> "cellular"
             capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true -> "ethernet"
             activeNetwork == null -> ""
@@ -103,9 +100,8 @@ class SessionAttributesCollector(
         }
 
         val ipAddress = resolveIpAddress()
-        val ssid = if (wifiActive) resolveSsid() else ""
 
-        return NetworkSnapshot(interfaceType, ipAddress, vpnActive, ssid)
+        return NetworkSnapshot(interfaceType, ipAddress, vpnActive, resolveSsid())
     }
 
     private fun resolveIpAddress(): String {

--- a/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
+++ b/android/src/main/java/com/mattermost/networkclient/sessionattributes/SessionAttributesCollector.kt
@@ -90,7 +90,9 @@ class SessionAttributesCollector(
         val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
 
         val vpnActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
-        val wifiActive = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+        val wifiActive = connectivityManager.allNetworks.any { network ->
+            connectivityManager.getNetworkCapabilities(network)?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+        }
         val interfaceType = when {
             vpnActive -> "vpn"
             wifiActive -> "wifi"

--- a/ios/SessionAttributes/SessionAttributesCollector.swift
+++ b/ios/SessionAttributes/SessionAttributesCollector.swift
@@ -27,8 +27,8 @@ public class SessionAttributesCollector: NSObject {
     private var wifiAvailable = false
     private var locationManager: CLLocationManager?
 
-    private static let ssidUnavailable = 
-        Bundle.main.bundleIdentifier?.contains("NotificationService") == true
+    private static let ssidUnavailable = Bundle.main.bundleURL.pathExtension == "appex" && 
+        Bundle.main.bundleIdentifier?.contains("NotificationService") ?? false
 
     private override init() {
         super.init()

--- a/ios/SessionAttributes/SessionAttributesCollector.swift
+++ b/ios/SessionAttributes/SessionAttributesCollector.swift
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import CoreLocation
 import Foundation
 import Network
 import NetworkExtension
@@ -13,7 +14,7 @@ struct NetworkSnapshot {
     let ssid: String
 }
 
-public class SessionAttributesCollector {
+public class SessionAttributesCollector: NSObject {
     public static let shared = SessionAttributesCollector()
 
     private let store = SessionAttributesStore.shared
@@ -23,11 +24,14 @@ public class SessionAttributesCollector {
     private let pathMonitor = NWPathMonitor()
     private var cachedInterfaceType = ""
     private var cachedSsid = ""
-    private let ssidUnavailable: Bool
+    private var wifiAvailable = false
+    private var locationManager: CLLocationManager?
 
-    private init() {
-        ssidUnavailable = Bundle.main.bundlePath.hasSuffix(".appex") &&
-            Bundle.main.bundleIdentifier?.contains("NotificationService") == true
+    private static let ssidUnavailable = 
+        Bundle.main.bundleIdentifier?.contains("NotificationService") == true
+
+    private override init() {
+        super.init()
 
         pathMonitor.pathUpdateHandler = { [weak self] path in
             guard let self else {
@@ -45,13 +49,22 @@ public class SessionAttributesCollector {
                 self.cachedInterfaceType = "other"
             }
 
-            if self.cachedInterfaceType == "wifi" {
+            self.wifiAvailable = path.availableInterfaces.contains { $0.type == .wifi }
+            if self.wifiAvailable {
                 self.refreshSsid()
             } else {
                 self.cachedSsid = ""
             }
         }
         pathMonitor.start(queue: monitorQueue)
+
+        if !Self.ssidUnavailable {
+            DispatchQueue.main.async {
+                let manager = CLLocationManager()
+                manager.delegate = self
+                self.locationManager = manager
+            }
+        }
     }
 
     func collect(_ name: String, serverUrl: String) -> String {
@@ -119,18 +132,17 @@ public class SessionAttributesCollector {
         let ipAddress = resolveIpAddress()
         return monitorQueue.sync {
             let interfaceType = vpnActive ? "vpn" : cachedInterfaceType
-            let ssid = interfaceType == "wifi" ? cachedSsid : ""
             return NetworkSnapshot(
                 interfaceType: interfaceType,
                 ipAddress: ipAddress,
                 vpnActive: vpnActive,
-                ssid: ssid
+                ssid: cachedSsid
             )
         }
     }
 
     private func refreshSsid() {
-        guard !ssidUnavailable else {
+        guard !Self.ssidUnavailable else {
             cachedSsid = ""
             return
         }
@@ -149,6 +161,9 @@ public class SessionAttributesCollector {
                     ssid = ""
                 }
                 self.monitorQueue.async {
+                    guard self.wifiAvailable else {
+                        return
+                    }
                     self.cachedSsid = ssid
                 }
             }
@@ -223,5 +238,16 @@ public class SessionAttributesCollector {
             ptr = next
         }
         return address
+    }
+}
+
+extension SessionAttributesCollector: CLLocationManagerDelegate {
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        monitorQueue.async {
+            guard self.wifiAvailable else {
+                return
+            }
+            self.refreshSsid()
+        }
     }
 }

--- a/react-native-network-client-session-attributes.podspec
+++ b/react-native-network-client-session-attributes.podspec
@@ -18,8 +18,8 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 # the collision cannot be fixed in place.
 #
 # The sources here depend only on system frameworks (Foundation, Network,
-# NetworkExtension, SystemConfiguration, CryptoKit), which is what makes them
-# safe to link into app extensions.
+# NetworkExtension, SystemConfiguration, CryptoKit, CoreLocation), which is what
+# makes them safe to link into app extensions.
 #
 # Swift module name is react_native_network_client_session_attributes (CocoaPods
 # replaces the hyphens in the pod name with underscores).


### PR DESCRIPTION
#### Summary
The `ssid` session attribute was never reaching the server. Two causes:
1. On both platforms the SSID was only read when Wi-Fi was the *primary* interface, so an active VPN — which takes over the reported interface type — suppressed it entirely. 
2. On iOS, the cached SSID was additionally only refreshed on network path changes, so it stayed empty if location authorization was granted too late.

This PR keys SSID collection on whether Wi-Fi is an available transport rather than the primary interface type, on both platforms. On iOS it also observes `locationManagerDidChangeAuthorization` so the cached value refreshes as soon as authorization is granted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70388